### PR TITLE
We should follow HTTP 301 redirects to ensure libraries get downloaded.

### DIFF
--- a/BuildTools/ubuntu/build.sh
+++ b/BuildTools/ubuntu/build.sh
@@ -74,7 +74,7 @@ install_library()
 
     if ! [ -f "$LIB_FILENAME" ] ; then
 	echo "$LIB_FILENAME not found. Downloading..."
-        curl -O $LIB_URL
+        curl -L -O $LIB_URL
     else
 	echo "$LIB_FILENAME found.  Download skipped."
     fi

--- a/BuildTools/ubuntu/build64.sh
+++ b/BuildTools/ubuntu/build64.sh
@@ -75,7 +75,7 @@ install_library()
 
     if ! [ -f "$LIB_FILENAME" ] ; then
 	echo "$LIB_FILENAME not found. Downloading..."
-        curl -O $LIB_URL
+        curl -L -O $LIB_URL
     else
 	echo "$LIB_FILENAME found.  Download skipped."
     fi


### PR DESCRIPTION
This change was made to accomodate this particular case:

$ curl http://c-ares.haxx.se/download/c-ares-1.10.0.tar.gz
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://c-ares.haxx.se/download/c-ares-1.10.0.tar.gz">here</a>.</p>
<hr>
<address>Apache Server at c-ares.haxx.se Port 80</address>
</body></html>