### PR TITLE
V241

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.gal
 *.pyc
 
+.vscode/
 deps/
 
 swig/*.gwt

--- a/BuildTools/macosx/GNUmakefile
+++ b/BuildTools/macosx/GNUmakefile
@@ -130,6 +130,8 @@ build-geoda-mac:
 	install_name_tool -change "$(GEODA_HOME)/libraries/lib/libspatialite.5.dylib" "@executable_path/../Resources/plugins/libspatialite.5.dylib" build/GeoDa.app/Contents/Resources/plugins/libgdal.20.dylib 
 	install_name_tool -change "$(GEODA_HOME)/libraries/lib/libfreexl.1.dylib" "@executable_path/../Resources/plugins/libfreexl.1.dylib" build/GeoDa.app/Contents/Resources/plugins/libgdal.20.dylib 
 	install_name_tool -change "$(GEODA_HOME)/libraries/lib/libproj.0.dylib" "@executable_path/../Resources/plugins/libproj.0.dylib" build/GeoDa.app/Contents/Resources/plugins/libgdal.20.dylib 
+	install_name_tool -change "/usr/local/opt/openssl/lib/libssl.1.0.0.dylib" "@executable_path/../Resources/plugins/libssl.1.0.0.dylib" build/GeoDa.app/Contents/Resources/plugins/libgdal.20.dylib
+	install_name_tool -change "/usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib" "@executable_path/../Resources/plugins/libcrypto.1.0.0.dylib" build/GeoDa.app/Contents/Resources/plugins/libgdal.20.dylib
 	install_name_tool -change "$(GEODA_HOME)/libraries/lib/libsqlite3.0.dylib" "@executable_path/../Resources/plugins/libsqlite3.0.dylib" build/GeoDa.app/Contents/Resources/plugins/libgdal.20.dylib 
 	install_name_tool -change "$(GEODA_HOME)/libraries/lib/libgeos_c.1.dylib" "@executable_path/../Resources/plugins/libgeos_c.1.dylib" build/GeoDa.app/Contents/Resources/plugins/libgdal.20.dylib 
 	install_name_tool -change "$(GEODA_HOME)/libraries/lib/libgeos-3.3.8.dylib" "@executable_path/../Resources/plugins/libgeos-3.3.8.dylib" build/GeoDa.app/Contents/Resources/plugins/libgdal.20.dylib 

--- a/BuildTools/ubuntu/create_deb_18.04.sh
+++ b/BuildTools/ubuntu/create_deb_18.04.sh
@@ -39,7 +39,7 @@ fi
 
 rm -f *.deb
 if [ $# -ne 1 ]; then
-    dpkg -b product/ geoda_1.12-1xenial1.deb
+    dpkg -b product/ geoda_1.12-1bionic1.deb
 else
     dpkg -b product/ geoda_1.12-1$1.deb
 fi

--- a/BuildTools/ubuntu/package/DEBIAN/control1804
+++ b/BuildTools/ubuntu/package/DEBIAN/control1804
@@ -1,5 +1,5 @@
 Package: geoda
-Version: 1.12-1xenial1
+Version: 1.12-1bionic1
 Architecture: amd64
 Priority: optional
 Section: graphics

--- a/DataViewer/OGRTable.cpp
+++ b/DataViewer/OGRTable.cpp
@@ -1189,7 +1189,18 @@ bool OGRTable::RenameSimpleCol(int col, int time, const wxString& new_name)
 	return true;
 }
 
-wxString OGRTable::GetCellString(int row, int col, int time)
+int OGRTable::GetCellStringLength(int row, int col, bool use_disp_decimal)
+{
+    int str_length = 0;
+    int ts = GetColTimeSteps(col);
+    for (int t=0; t<ts; ++t) {
+        wxString val = GetCellString(row, col, t, use_disp_decimal);
+        if (val.length() > str_length) str_length = val.length();
+    }
+    return str_length;
+}
+
+wxString OGRTable::GetCellString(int row, int col, int time, bool use_disp_decimal)
 {
 	// NOTE: if called from wxGrid, must use row_order[row] to permute
 	if (row < 0 || row >= rows) return wxEmptyString;
@@ -1198,15 +1209,16 @@ wxString OGRTable::GetCellString(int row, int col, int time)
         cur_type == GdaConst::unknown_type) {
         return wxEmptyString;
     }
-    // get display number of decimals
-	int disp_dec = GetColDispDecimals(col);
     
 	// mapping col+time to underneath OGR col
     OGRColumn* ogr_col = FindOGRColumn(col, time);
 	if (ogr_col == NULL) {
 		return "";
 	}
-    return ogr_col->GetValueAt(row, disp_dec, m_wx_encoding);
+    // get display number of decimals
+    int col_dec = GetColDecimals(col, time);
+    if (use_disp_decimal) col_dec = GetColDispDecimals(col);
+    return ogr_col->GetValueAt(row, col_dec, m_wx_encoding);
 }
 
 

--- a/DataViewer/OGRTable.h
+++ b/DataViewer/OGRTable.h
@@ -174,8 +174,9 @@ public:
 	virtual bool ColChangeDisplayedDecimals(int col, int new_disp_dec);
 	virtual bool RenameGroup(int col, const wxString& new_name);
 	virtual bool RenameSimpleCol(int col, int time, const wxString& new_name);
-	virtual wxString GetCellString(int row, int col, int time=0);
-	virtual bool SetCellFromString(int row, int col, int time,
+	virtual wxString GetCellString(int row, int col, int time=0, bool use_disp_decimal=false);
+    virtual int   GetCellStringLength(int row, int col, bool use_disp_decimal=true);
+    virtual bool SetCellFromString(int row, int col, int time,
 								   const wxString &value);
 	virtual int  InsertCol(GdaConst::FieldType type, const wxString& name,
 						   int pos=-1, int time_steps=1,

--- a/DataViewer/TableFrame.cpp
+++ b/DataViewer/TableFrame.cpp
@@ -113,27 +113,18 @@ TableFrame::TableFrame(wxFrame *parent, Project* project,
 	for (int i=0, iend=table_base->GetNumberCols(); i<iend; i++) {
 		double cur_col_size = grid->GetColSize(i);
 		double cur_lbl_len = grid->GetColLabelValue(i).length();
-		double max_cell_len = 0;
+		double max_cell_len = cur_lbl_len;
 		for (int j=0; j<sample-1; ++j) {
-			wxString cv = grid->GetCellValue(j, i);
-			cv.Trim(true);
-			cv.Trim(false);
-            if (cv.length() > max_cell_len) max_cell_len = cv.length();
+			//wxString cv = grid->GetCellValue(j, i);
+            int cv_length = table_int->GetCellStringLength(j,i,true);
+            if (cv_length > max_cell_len) max_cell_len = cv_length;
 		}
-		if (max_cell_len > cur_lbl_len &&
-			max_cell_len >= 1 && cur_lbl_len >= 1) {
-			// attempt to scale up col width based on cur_col_size
-			double fac = max_cell_len / cur_lbl_len;
-			if (fac < 1) fac = 1;
-			if (fac > 5) fac = 5;
-            fac = fac * 1.2;
-            grid->SetColMinimalWidth(i, cur_col_size);
-			grid->SetColSize(i, cur_col_size * fac);
-		} else {
-			// add a few pixels of buffer to current label
-			grid->SetColMinimalWidth(i, cur_col_size+6);
-			grid->SetColSize(i, cur_col_size+6);
-		}
+        // width (pixel) per number
+        double pw = 10;
+        grid->SetColMinimalWidth(i, cur_lbl_len * pw + 8);
+        // attempt to scale up col width based on cur_col_size
+        //double fac = 1.2;
+        grid->SetColSize(i, max_cell_len * pw);
 	}
     grid->ForceRefresh();
 

--- a/DataViewer/TableInterface.h
+++ b/DataViewer/TableInterface.h
@@ -226,8 +226,10 @@ public:
 								 const wxString& new_name) = 0;
     /** wxGrid will call this function to fill data in displayed part 
      automatically. Returns formated string (e.g. nummeric numbers) */
-	virtual wxString GetCellString(int row, int col, int time=0) = 0;
-	/** Attempts to set the wxGrid cell from a user-entered value.  Returns
+	virtual wxString GetCellString(int row, int col, int time=0,  bool use_disp_decimal = false) = 0;
+    virtual int   GetCellStringLength(int row, int col, bool use_disp_decimal=true) = 0;
+
+    /** Attempts to set the wxGrid cell from a user-entered value.  Returns
 	 true on success. If failured, then IsCellFromStringFail() returns false
 	 and GetSetCellFromStringFailMsg() retuns a meaningful failure message
 	 that can be displayed to the user. */

--- a/DialogTools/CreatingWeightDlg.cpp
+++ b/DialogTools/CreatingWeightDlg.cpp
@@ -159,8 +159,8 @@ bool CreatingWeightDlg::Create(wxWindow* parent, wxWindowID id, const wxString& 
 	
 	SetParent(parent);
 	CreateControls();
-	GetSizer()->Fit(this);
-	GetSizer()->SetSizeHints(this);
+	//GetSizer()->Fit(this);
+	//GetSizer()->SetSizeHints(this);
 	Centre();
 	
 	return true;
@@ -212,7 +212,15 @@ void CreatingWeightDlg::CreateControls()
     m_spinn_inverse_knn = XRCCTRL(*this, "IDC_SPIN_POWER_KNN", wxSpinButton);
     
     m_btn_ok = XRCCTRL(*this, "wxID_OK", wxButton);
-    
+
+    wxScrolledWindow* win = wxDynamicCast(FindWindow( XRCID("ID_CREATE_WEIGHT_SCROLL_WIN")), wxScrolledWindow);
+
+    win->SetAutoLayout(true);
+    win->FitInside();
+    win->SetScrollRate(5, 5);
+
+    FitInside();
+
     m_X_time->Show(false);
     m_Y_time->Show(false);
     

--- a/DialogTools/ExportDataDlg.cpp
+++ b/DialogTools/ExportDataDlg.cpp
@@ -572,7 +572,7 @@ ExportDataDlg::CreateOGRLayer(wxString& ds_name, bool is_table,
     OGRSpatialReference new_ref;
     if (is_table) {
         spatial_ref = NULL; // table only data, void creating e.g. prj file
-    } else if (spatial_ref) {
+    } else {
         geom_type = ogr_adapter.MakeOGRGeometries(geometries, shape_type,
                                                   ogr_geometries, selected_rows);
         wxString str_crs = m_crs_input->GetValue();
@@ -587,7 +587,7 @@ ExportDataDlg::CreateOGRLayer(wxString& ds_name, bool is_table,
             new_ref.importFromEPSG(4326);
             valid_input_crs = true;
         }
-        if (valid_input_crs && !spatial_ref->IsSame(&new_ref)) {
+        if (spatial_ref && (valid_input_crs && !spatial_ref->IsSame(&new_ref))) {
             OGRCoordinateTransformation *poCT;
             poCT = OGRCreateCoordinateTransformation(spatial_ref, &new_ref);
             for (size_t i=0; i < ogr_geometries.size(); i++) {

--- a/DialogTools/ExportDataDlg.cpp
+++ b/DialogTools/ExportDataDlg.cpp
@@ -569,7 +569,7 @@ ExportDataDlg::CreateOGRLayer(wxString& ds_name, bool is_table,
     OGRDataAdapter& ogr_adapter = OGRDataAdapter::GetInstance();
 	vector<OGRGeometry*> ogr_geometries;
     OGRwkbGeometryType geom_type = wkbNone;
-    OGRSpatialReference new_ref = NULL;
+    OGRSpatialReference new_ref;
     if (is_table) {
         spatial_ref = NULL; // table only data, void creating e.g. prj file
     } else if (spatial_ref) {

--- a/DialogTools/LocaleSetupDlg.cpp
+++ b/DialogTools/LocaleSetupDlg.cpp
@@ -60,12 +60,15 @@ LocaleSetupDlg::LocaleSetupDlg(wxWindow* parent,
     m_txt_thousands->SetMaxLength(1);
     m_txt_decimal->SetMaxLength(1);
 
-    struct lconv *poLconv = localeconv();
-    wxString thousands_sep = poLconv->thousands_sep;
-    wxString decimal_point = poLconv->decimal_point;
+    const char* thousands_sep = CPLGetConfigOption("GEODA_LOCALE_SEPARATOR", ",");
+    const char* decimal_sep = CPLGetConfigOption("GEODA_LOCALE_DECIMAL", ".");
+
+    //struct lconv *poLconv = localeconv();
+    //wxString thousands_sep = poLconv->thousands_sep;
+    //wxString decimal_point = poLconv->decimal_point;
     
     m_txt_thousands->SetValue(thousands_sep);
-    m_txt_decimal->SetValue(decimal_point);
+    m_txt_decimal->SetValue(decimal_sep);
     
     SetParent(parent);
 	SetPosition(pos);
@@ -83,7 +86,7 @@ void LocaleSetupDlg::OnResetSysLocale( wxCommandEvent& event )
     m_txt_thousands->SetValue(thousands_sep);
     m_txt_decimal->SetValue(decimal_point);
     
-    wxString msg = _("Reset to system locale successfully. Please re-open current project with system locale.");
+    wxString msg = _("Reset to system locale successfully.");
     wxMessageDialog msg_dlg(this, msg,
                            _("Reset to system locale information"),
                            wxOK | wxOK_DEFAULT | wxICON_INFORMATION);
@@ -98,14 +101,14 @@ void LocaleSetupDlg::OnOkClick( wxCommandEvent& event )
     wxString thousands_sep = m_txt_thousands->GetValue();
     wxString decimal_point = m_txt_decimal->GetValue();
     
-    CPLSetConfigOption("GDAL_LOCALE_SEPARATOR",
+    CPLSetConfigOption("GEODA_LOCALE_SEPARATOR",
                        (const char*)thousands_sep.mb_str());
     if ( !decimal_point.IsEmpty() )
-        CPLSetConfigOption("GDAL_LOCALE_DECIMAL",
+        CPLSetConfigOption("GEODA_LOCALE_DECIMAL",
                            (const char*)decimal_point.mb_str());
    
     if (need_reopen) {
-        wxString msg = _("Locale for numbers has been setup successfully. Please re-open current project to enable this locale.");
+        wxString msg = _("Locale for numbers has been setup successfully.");
         wxMessageDialog msg_dlg(this, msg,
                                "Setup locale",
                                wxOK | wxOK_DEFAULT | wxICON_INFORMATION);

--- a/DialogTools/SpatialJoinDlg.cpp
+++ b/DialogTools/SpatialJoinDlg.cpp
@@ -186,6 +186,7 @@ AssignPolygonToPoint::AssignPolygonToPoint(BackgroundMapLayer* _ml,
                                 Project* _project, vector<wxInt64>& _poly_ids)
 : SpatialJoinWorker(_ml, _project)
 {
+    join_variable = false;
     is_spatial_assign = true;
     poly_ids = _poly_ids;
     num_polygons = ml->GetNumRecords();
@@ -291,6 +292,7 @@ AssignPolygonToLine::AssignPolygonToLine(BackgroundMapLayer* _ml,
                                          vector<wxInt64>& _poly_ids)
 : SpatialJoinWorker(_ml, _project)
 {
+    join_variable = false;
     is_spatial_assign = true;
     poly_ids = _poly_ids;
     num_polygons = ml->GetNumRecords();

--- a/ShapeOperations/OGRFieldProxy.cpp
+++ b/ShapeOperations/OGRFieldProxy.cpp
@@ -73,21 +73,28 @@ OGRFieldProxy::OGRFieldProxy(OGRFieldDefn *field_defn)
 	
 	if (ogr_type == OFTString){
 		type = GdaConst::string_type;
+        if (length == 0) length = GdaConst::max_dbf_string_len;
 	}
 	else if (ogr_type == OFTInteger64 || ogr_type == OFTInteger) {
 		type = GdaConst::long64_type;
+        if (length == 0) length = GdaConst::max_dbf_long_len;
 	}
 	else if (ogr_type == OFTReal) {
 		type = GdaConst::double_type;
+        if (length == 0) length = GdaConst::max_dbf_long_len;
+        if (decimals == 0) decimals = GdaConst::max_dbf_double_decimals;
 	}
     else if (ogr_type == OFTDate ) {
         type = GdaConst::date_type;
+        if (length == 0) length = GdaConst::default_dbf_string_len;
         
     } else if (ogr_type == OFTTime) {
         type = GdaConst::time_type;
+        if (length == 0) length = GdaConst::default_dbf_string_len;
         
     } else if (ogr_type == OFTDateTime) {
         type = GdaConst::datetime_type;
+        if (length == 0) length = GdaConst::default_dbf_string_len;
     }
 }
 

--- a/rc/dialogs.xrc
+++ b/rc/dialogs.xrc
@@ -3472,8 +3472,13 @@
     <title>Weights File Creation</title>
     <centered>1</centered>
     <object class="wxBoxSizer">
+    <orient>wxVERTICAL</orient>
+    <object class="sizeritem">
+    <object class="wxScrolledWindow" name="ID_CREATE_WEIGHT_SCROLL_WIN">
+    <style>wxHSCROLL|wxVSCROLL</style>
+
+    <object class="wxBoxSizer">
       <orient>wxVERTICAL</orient>
-      <label/>
       <object class="sizeritem">
         <object class="wxBoxSizer">
           <object class="sizeritem">
@@ -4196,6 +4201,13 @@
         <flag>wxBOTTOM|wxALIGN_CENTRE_HORIZONTAL</flag>
         <border>8</border>
       </object>
+    </object>
+
+    </object>
+    <flag>wxEXPAND|wxALL</flag>
+    <option>1</option>
+    <border>7</border>
+    </object>
     </object>
   </object>
   <object class="wxDialog" name="IDD_ADD_ID_VARIABLE" subclass="AddIdVariable">

--- a/rc/menus.xrc
+++ b/rc/menus.xrc
@@ -219,6 +219,9 @@
           <checkable>1</checkable>
         </object>
       </object>
+      <object class="wxMenuItem" name="ID_TABLE_SET_LOCALE">
+          <label>Setup Number Formatting</label>
+      </object>
     </object>
     <object class="wxMenu" name="ID_CAT_CLASSIF_A_MENU">
       <label>&amp;Map</label>

--- a/version.h
+++ b/version.h
@@ -2,10 +2,10 @@ namespace Gda {
 	const int version_major = 1;
 	const int version_minor = 12;
 	const int version_build = 1;
-    const int version_subbuild = 239;
+    const int version_subbuild = 241;
 	const int version_year = 2019;
-	const int version_month = 5;
-    const int version_day = 28;
+    const int version_month = 6;
+    const int version_day = 17;
 	const int version_night = 0;
 	const int version_type = 2; // 0: alpha, 1: beta, 2: release
 }

--- a/version.h
+++ b/version.h
@@ -2,10 +2,10 @@ namespace Gda {
 	const int version_major = 1;
 	const int version_minor = 12;
 	const int version_build = 1;
-    const int version_subbuild = 237;
+    const int version_subbuild = 239;
 	const int version_year = 2019;
 	const int version_month = 5;
-    const int version_day = 16;
+    const int version_day = 28;
 	const int version_night = 0;
 	const int version_type = 2; // 0: alpha, 1: beta, 2: release
 }


### PR DESCRIPTION
#1898 Fix bug: Table merge bug: integers with commas are cut off 
Also add "Setup Number Formatting" to allow user to specify "thousand separator" and "decimal separator"
#1898 update fix with testing on merging feature
 fix ui issue of weights creation dialog: When use low resolution projection (e.g. 640x480), the weights creation dialog can not be fully displayed, and a verticle scroll bar is needed  in this case (as in other dialog e.g. k-means dialog)
fix a bug in spatial join (assign operation)
update build script on osx 10.7 for TSL1.2 support
update build scripts for Ubuntu 18.04


