### PR TITLE
Add windows installer for Windows7+

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -231,6 +231,7 @@ jobs:
           else
           {
             ISCC.exe /q installer\64bit\GeoDa.iss
+            ISCC.exe /q installer\64bit\GeoDa-win7+.iss
           } 
           dir
 
@@ -238,6 +239,11 @@ jobs:
         with:
           name: GeoDa-Windows-${{ env.platform }}-installer
           path: ${{ github.workspace }}\BuildTools\windows\GeoDa_1.20_${{ env.platform }}_Setup.exe
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: GeoDa-Windows7+-${{ env.platform }}-installer
+          path: ${{ github.workspace }}\BuildTools\windows\GeoDa_1.20_win7+${{ env.platform }}_Setup.exe
 
 
 

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -227,6 +227,7 @@ jobs:
           if($env:platform -eq "x86")
           {
             ISCC.exe /q installer\32bit\GeoDa.iss
+            ISCC.exe /q installer\32bit\GeoDa-win7+.iss
           } 
           else
           {

--- a/BuildTools/windows/installer/32bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/32bit/GeoDa-win7+.iss
@@ -1,0 +1,234 @@
+[Setup]
+AppName=GeoDa                                                      
+AppPublisher=GeoDa Center
+AppPublisherURL=https://spatial.uchiago.edu/
+AppSupportURL=https://spatial.uchiago.edu/
+AppUpdatesURL=https://spatial.uchiago.edu/
+AppSupportPhone=(480)965-7533
+AppVersion=1.20
+DefaultDirName={localappdata}\GeoDa
+DefaultGroupName=GeoDa Software
+; Since no icons will be created in "{group}", we don't need the wizard
+; to ask for a Start Menu folder name:
+;DisableProgramGroupPage=yes
+UninstallDisplayIcon={localappdata}\GeoDa\GeoDa.exe
+Compression=lzma2
+SolidCompression=yes
+OutputDir=..\..
+OutputBaseFilename=GeoDa_1.20_win7+x86_Setup
+;OutputDir=userdocs:Inno Setup Examples Output
+
+ChangesAssociations=yes
+
+ShowLanguageDialog=yes
+
+[Languages]
+Name: "en"; MessagesFile: "compiler:Default.isl"
+
+[dirs]
+Name: "{localappdata}\GeoDa";  Permissions: users-full; Check: InitializeSetup
+Name: "{localappdata}\GeoDa\basemap_cache";  Permissions: users-full
+Name: "{localappdata}\GeoDa\lang";  Permissions: users-full
+Name: "{localappdata}\GeoDa\proj";  Permissions: users-full
+
+[Files]
+Source: "..\..\Release\GeoDa.exe"; DestDir: "{localappdata}\GeoDa"; DestName: "GeoDa.exe"
+Source: "..\..\..\CommonDistFiles\GeoDa.ico"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\copyright.txt"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\GPLv3.txt"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\geoda_prefs.sqlite"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\geoda_prefs.json"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\web_plugins\*"; DestDir: "{localappdata}\GeoDa\web_plugins"; Flags: recursesubdirs
+Source: "..\..\..\CommonDistFiles\proj\*"; DestDir: "{localappdata}\GeoDa\proj"; Flags: recursesubdirs
+
+
+Source: "VC_redist.x86.exe"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\temp\OpenCL\sdk\bin\x86\OpenCL.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\temp\wxWidgets\lib\vc_dll\wxmsw314u_vc_custom.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\temp\wxWidgets\lib\vc_dll\wxmsw314u_gl_vc_custom.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\expat.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\freexl.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\gdal302.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\geos.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\geos_c.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\iconv.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libcrypto-1_1.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libcurl.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libmysql.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libpq.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libssl-1_1.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libxml2.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\openjp2.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\proj.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\proj_6_1.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\spatialite.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\sqlite3.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\xerces-c_3_2.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\zlib1.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\gdal\plugins\ogr_OCI.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_PG.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_MSSQLSpatial.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\gdal\plugins-external\ogr_FileGDB.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\..\Algorithms\lisa_kernel.cl"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\..\internationalization\lang\*"; DestDir: "{localappdata}\GeoDa\lang"; Flags: recursesubdirs
+Source: "..\..\libraries\bin\gdal-data\*"; DestDir: "{localappdata}\GeoDa\data"; Flags: recursesubdirs
+
+;Source: "Readme.txt"; DestDir: "{localappdata}\GeoDa"; Flags: isreadme
+
+[Icons]
+Name: "{group}\GeoDa"; Filename: "{localappdata}\GeoDa\GeoDa.exe"
+;Name: "{group}\GeoDa"; Filename: "{localappdata}\GeoDa\run_geoda.bat"; IconFilename: "{localappdata}\GeoDa\GeoDa.ico"
+Name: "{group}\Uninstall"; Filename: "{uninstallexe}"
+Name: "{commondesktop}\GeoDa"; Filename: "{localappdata}\GeoDa\GeoDa.exe"
+;Name: "{commondesktop}\GeoDa"; Filename: "{localappdata}\GeoDa\run_geoda.bat"; IconFilename: "{localappdata}\GeoDa\GeoDa.ico"
+
+[Registry]
+; set PATH
+; set GEODA_GDAL_DATA
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{localappdata}\GeoDa\data"; Flags: preservestringtype uninsdeletevalue
+; set GEODA_OGR_DRIVER_PATH
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{localappdata}\GeoDa"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{localappdata}\GeoDa\proj"; Flags: preservestringtype uninsdeletevalue
+
+Root: HKCR; Subkey: ".gda"; ValueType: string; ValueName: ""; ValueData: "GeoDaProjectFile"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "GeoDaProjectFile"; ValueType: string; ValueName: ""; ValueData: "GeoDa Project File"; Flags: uninsdeletekey
+Root: HKCR; Subkey: "GeoDaProjectFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{localappdata}\GeoDa\GeoDa.exe,0"
+Root: HKCR; Subkey: "GeoDaProjectFile\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{localappdata}\GeoDa\GeoDa.exe"" ""%1"""
+
+; set Browser Emulation for wxWebView to IE 11.  IE 10 or earlier does not work with current D3
+Root: "HKCU"; Subkey: "Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName:"GeoDa.exe"; ValueData:"$2AF9"
+
+;Local Machine
+Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName: "GeoDa.exe"; ValueData: "$2AF9"
+
+;run as admin
+;Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\"; ValueType: String; ValueName: "{localappdata}\GeoDa\GeoDa.exe"; ValueData: "RUNASADMIN"; Flags: uninsdeletekeyifempty uninsdeletevalue; MinVersion: 0,6.1
+
+[Code]
+function IsX64: Boolean;
+begin
+  Result := Is64BitInstallMode and (ProcessorArchitecture = paX64);
+end;
+
+function IsIA64: Boolean;
+begin
+  Result := Is64BitInstallMode and (ProcessorArchitecture = paIA64);
+end;
+
+function IsOtherArch: Boolean;
+begin
+  Result := not IsX64 and not IsIA64;
+end;
+
+function VCRedistNeedsInstall: Boolean;
+begin
+  Result := not RegKeyExists(HKLM,'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{03d1453c-7d5c-479c-afea-8482f406e036}');
+end;
+
+function GetUninstallString: string;
+var
+  sUnInstPath: string;
+  sUnInstallString: String;
+begin
+  Result := '';
+  sUnInstPath := ExpandConstant('Software\Microsoft\Windows\CurrentVersion\Uninstall\GeoDa_is1'); //Your App GUID/ID
+  sUnInstallString := '';
+  if not RegQueryStringValue(HKLM, sUnInstPath, 'UninstallString', sUnInstallString) then
+    RegQueryStringValue(HKCU, sUnInstPath, 'UninstallString', sUnInstallString);
+  Result := sUnInstallString;
+end;
+
+function IsUpgrade: Boolean;
+begin
+  Result := (GetUninstallString() <> '');
+end;
+
+function InitializeSetup: Boolean;
+var
+  V: Integer;
+  iResultCode: Integer;
+  sUnInstallString: string;
+begin
+  Result := True; // in case when no previous version is found
+  if RegValueExists(HKEY_LOCAL_MACHINE,'Software\Microsoft\Windows\CurrentVersion\Uninstall\GeoDa_is1', 'UninstallString') then  //Your App GUID/ID
+  begin
+    V := MsgBox(ExpandConstant('An old version of GeoDa was detected. Please uninstall it before continuing.'), mbInformation, MB_YESNO); //Custom Message if App installed
+    if V = IDYES then
+    begin
+      sUnInstallString := GetUninstallString();
+      sUnInstallString :=  RemoveQuotes(sUnInstallString);
+      Exec(ExpandConstant(sUnInstallString), '', '', SW_SHOW, ewWaitUntilTerminated, iResultCode);
+      Result := True; //if you want to proceed after uninstall
+      //Exit; //if you want to quit after uninstall
+    end
+    else
+      Result := False; //when older version present and not uninstalled
+  end;
+end;
+
+var
+  Button: TNewButton;
+  ComboBox: TNewComboBox;
+  CustomPage: TWizardPage;     
+  langCode: string;
+
+procedure ComboBoxChange(Sender: TObject);
+begin
+  case ComboBox.ItemIndex of
+    0:
+    begin
+      langCode := '58';
+    end;
+    1:
+    begin
+      langCode := '45';   // chinese
+    end;
+    2:
+    begin
+      langCode := '179';  // spanish
+    end;
+    3:
+    begin
+      langCode := '159';  // russian
+    end;
+  end;
+end;
+
+procedure InitializeWizard;
+var
+  DescLabel: TLabel;
+begin
+  CustomPage := CreateCustomPage(wpSelectDir, 'Language Selection', 'Please select a language for GeoDa');
+
+  DescLabel := TLabel.Create(WizardForm);
+  DescLabel.Parent := CustomPage.Surface;
+  DescLabel.Left := 0;
+  DescLabel.Top := 0;
+  DescLabel.Caption := '';
+
+  ComboBox := TNewComboBox.Create(WizardForm);
+  ComboBox.Parent := CustomPage.Surface;
+  ComboBox.Left := 0;
+  ComboBox.Top := DescLabel.Top + DescLabel.Height + 6;  
+  ComboBox.Width := 220;
+  ComboBox.Style := csDropDownList;
+  ComboBox.Items.Add('English');
+  ComboBox.Items.Add('Chinese (Simplified)');
+  ComboBox.Items.Add('Spanish');
+  ComboBox.Items.Add('Russian');
+  ComboBox.ItemIndex := 0;
+  ComboBox.OnChange := @ComboBoxChange;
+  langCode := '58';
+end;
+
+function getLangCode(Param: String): String;
+begin
+  Result :=  langCode;
+end;
+
+[INI]
+Filename: "{localappdata}\GeoDa\lang\config.ini"; Section: "Translation"; Key: "Language"; String: {code:getLangCode|{localappdata}\GeoDa}
+
+[Run]
+Filename: {localappdata}\GeoDa\VC_redist.x86.exe; StatusMsg: Installing Visual C++ Redistributable for Visual Studio 2019 (14.28.29913.0)...; Check: VCRedistNeedsInstall

--- a/BuildTools/windows/installer/32bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/32bit/GeoDa-win7+.iss
@@ -6,12 +6,12 @@ AppSupportURL=https://spatial.uchiago.edu/
 AppUpdatesURL=https://spatial.uchiago.edu/
 AppSupportPhone=(480)965-7533
 AppVersion=1.20
-DefaultDirName={localappdata}\GeoDa
+DefaultDirName={pf}\GeoDa
 DefaultGroupName=GeoDa Software
 ; Since no icons will be created in "{group}", we don't need the wizard
 ; to ask for a Start Menu folder name:
 ;DisableProgramGroupPage=yes
-UninstallDisplayIcon={localappdata}\GeoDa\GeoDa.exe
+UninstallDisplayIcon={app}\GeoDa.exe
 Compression=lzma2
 SolidCompression=yes
 OutputDir=..\..
@@ -26,75 +26,76 @@ ShowLanguageDialog=yes
 Name: "en"; MessagesFile: "compiler:Default.isl"
 
 [dirs]
-Name: "{localappdata}\GeoDa";  Permissions: users-full; Check: InitializeSetup
-Name: "{localappdata}\GeoDa\basemap_cache";  Permissions: users-full
-Name: "{localappdata}\GeoDa\lang";  Permissions: users-full
-Name: "{localappdata}\GeoDa\proj";  Permissions: users-full
+Name: "{app}"; Check: InitializeSetup
+Name: "{userappdata}\GeoDa\basemap_cache";  Permissions: users-modify
+Name: "{userappdata}\GeoDa\lang";  Permissions: users-modify
 
 [Files]
-Source: "..\..\Release\GeoDa.exe"; DestDir: "{localappdata}\GeoDa"; DestName: "GeoDa.exe"
-Source: "..\..\..\CommonDistFiles\GeoDa.ico"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\copyright.txt"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\GPLv3.txt"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\geoda_prefs.sqlite"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\geoda_prefs.json"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\web_plugins\*"; DestDir: "{localappdata}\GeoDa\web_plugins"; Flags: recursesubdirs
-Source: "..\..\..\CommonDistFiles\proj\*"; DestDir: "{localappdata}\GeoDa\proj"; Flags: recursesubdirs
+Source: "..\..\Release\GeoDa.exe"; DestDir: "{app}"; DestName: "GeoDa.exe"
+Source: "..\..\..\CommonDistFiles\GeoDa.ico"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\copyright.txt"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\GPLv3.txt"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{userappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\geoda_prefs.sqlite"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\geoda_prefs.json"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\web_plugins\*"; DestDir: "{app}\web_plugins"; Flags: recursesubdirs
+Source: "..\..\..\CommonDistFiles\proj\*"; DestDir: "{app}\proj"; Flags: recursesubdirs
 
 
-Source: "VC_redist.x86.exe"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\temp\OpenCL\sdk\bin\x86\OpenCL.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\temp\wxWidgets\lib\vc_dll\wxmsw314u_vc_custom.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\temp\wxWidgets\lib\vc_dll\wxmsw314u_gl_vc_custom.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\expat.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\freexl.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\gdal302.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\geos.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\geos_c.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\iconv.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libcrypto-1_1.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libcurl.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libmysql.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libpq.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libssl-1_1.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libxml2.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\openjp2.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\proj.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\proj_6_1.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\spatialite.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\sqlite3.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\xerces-c_3_2.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\zlib1.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\gdal\plugins\ogr_OCI.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_PG.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_MSSQLSpatial.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\gdal\plugins-external\ogr_FileGDB.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\..\Algorithms\lisa_kernel.cl"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\..\internationalization\lang\*"; DestDir: "{localappdata}\GeoDa\lang"; Flags: recursesubdirs
-Source: "..\..\libraries\bin\gdal-data\*"; DestDir: "{localappdata}\GeoDa\data"; Flags: recursesubdirs
+Source: "VC_redist.x86.exe"; DestDir: "{app}"
+Source: "..\..\temp\OpenCL\sdk\bin\x86\OpenCL.dll"; DestDir: "{app}"
+Source: "..\..\temp\wxWidgets\lib\vc_dll\wxmsw314u_vc_custom.dll"; DestDir: "{app}"
+Source: "..\..\temp\wxWidgets\lib\vc_dll\wxmsw314u_gl_vc_custom.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\expat.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\freexl.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\gdal302.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\geos.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\geos_c.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\iconv.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libcrypto-1_1.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libcurl.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libmysql.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libpq.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libssl-1_1.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libxml2.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\openjp2.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\proj.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\proj_6_1.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\spatialite.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\sqlite3.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\xerces-c_3_2.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\zlib1.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\gdal\plugins\ogr_OCI.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_PG.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_MSSQLSpatial.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\gdal\plugins-external\ogr_FileGDB.dll"; DestDir: "{app}"
+Source: "..\..\..\..\Algorithms\lisa_kernel.cl"; DestDir: "{app}"
+Source: "..\..\..\..\internationalization\lang\*"; DestDir: "{app}\lang"; Flags: recursesubdirs
+Source: "..\..\..\..\internationalization\lang\config.ini"; DestDir: "{userappdata}\GeoDa\lang"
+Source: "..\..\libraries\bin\gdal-data\*"; DestDir: "{app}\data"; Flags: recursesubdirs
 
-;Source: "Readme.txt"; DestDir: "{localappdata}\GeoDa"; Flags: isreadme
+;Source: "Readme.txt"; DestDir: "{app}"; Flags: isreadme
 
 [Icons]
-Name: "{group}\GeoDa"; Filename: "{localappdata}\GeoDa\GeoDa.exe"
-;Name: "{group}\GeoDa"; Filename: "{localappdata}\GeoDa\run_geoda.bat"; IconFilename: "{localappdata}\GeoDa\GeoDa.ico"
+Name: "{group}\GeoDa"; Filename: "{app}\GeoDa.exe"
+;Name: "{group}\GeoDa"; Filename: "{app}\run_geoda.bat"; IconFilename: "{app}\GeoDa.ico"
 Name: "{group}\Uninstall"; Filename: "{uninstallexe}"
-Name: "{commondesktop}\GeoDa"; Filename: "{localappdata}\GeoDa\GeoDa.exe"
-;Name: "{commondesktop}\GeoDa"; Filename: "{localappdata}\GeoDa\run_geoda.bat"; IconFilename: "{localappdata}\GeoDa\GeoDa.ico"
+Name: "{commondesktop}\GeoDa"; Filename: "{app}\GeoDa.exe"
+;Name: "{commondesktop}\GeoDa"; Filename: "{app}\run_geoda.bat"; IconFilename: "{app}\GeoDa.ico"
 
 [Registry]
 ; set PATH
 ; set GEODA_GDAL_DATA
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{localappdata}\GeoDa\data"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{app}\data"; Flags: preservestringtype uninsdeletevalue
 ; set GEODA_OGR_DRIVER_PATH
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{localappdata}\GeoDa"; Flags: preservestringtype uninsdeletevalue
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{localappdata}\GeoDa\proj"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{app}"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{app}\proj"; Flags: preservestringtype uninsdeletevalue
 
 Root: HKCR; Subkey: ".gda"; ValueType: string; ValueName: ""; ValueData: "GeoDaProjectFile"; Flags: uninsdeletevalue
 Root: HKCR; Subkey: "GeoDaProjectFile"; ValueType: string; ValueName: ""; ValueData: "GeoDa Project File"; Flags: uninsdeletekey
-Root: HKCR; Subkey: "GeoDaProjectFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{localappdata}\GeoDa\GeoDa.exe,0"
-Root: HKCR; Subkey: "GeoDaProjectFile\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{localappdata}\GeoDa\GeoDa.exe"" ""%1"""
+Root: HKCR; Subkey: "GeoDaProjectFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\GeoDa.exe,0"
+Root: HKCR; Subkey: "GeoDaProjectFile\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\GeoDa.exe"" ""%1"""
 
 ; set Browser Emulation for wxWebView to IE 11.  IE 10 or earlier does not work with current D3
 Root: "HKCU"; Subkey: "Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName:"GeoDa.exe"; ValueData:"$2AF9"
@@ -103,7 +104,7 @@ Root: "HKCU"; Subkey: "Software\Microsoft\Internet Explorer\Main\FeatureControl\
 Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName: "GeoDa.exe"; ValueData: "$2AF9"
 
 ;run as admin
-;Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\"; ValueType: String; ValueName: "{localappdata}\GeoDa\GeoDa.exe"; ValueData: "RUNASADMIN"; Flags: uninsdeletekeyifempty uninsdeletevalue; MinVersion: 0,6.1
+;Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\"; ValueType: String; ValueName: "{app}\GeoDa.exe"; ValueData: "RUNASADMIN"; Flags: uninsdeletekeyifempty uninsdeletevalue; MinVersion: 0,6.1
 
 [Code]
 function IsX64: Boolean;
@@ -228,7 +229,7 @@ begin
 end;
 
 [INI]
-Filename: "{localappdata}\GeoDa\lang\config.ini"; Section: "Translation"; Key: "Language"; String: {code:getLangCode|{localappdata}\GeoDa}
+Filename: "{userappdata}\GeoDa\lang\config.ini"; Section: "Translation"; Key: "Language"; String: {code:getLangCode|{userappdata}\GeoDa}
 
 [Run]
-Filename: {localappdata}\GeoDa\VC_redist.x86.exe; StatusMsg: Installing Visual C++ Redistributable for Visual Studio 2019 (14.28.29913.0)...; Check: VCRedistNeedsInstall
+Filename: {app}\VC_redist.x86.exe; StatusMsg: Installing Visual C++ Redistributable for Visual Studio 2019 (14.28.29913.0)...; Check: VCRedistNeedsInstall

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -6,7 +6,7 @@ AppSupportURL=https://spatial.uchiago.edu/
 AppUpdatesURL=https://spatial.uchiago.edu/
 AppSupportPhone=(480)965-7533
 AppVersion=1.20
-DefaultDirName={code:GetDefaultDirName}
+DefaultDirName={pf}\GeoDa Software
 DefaultGroupName=GeoDa Software
 ; Since no icons will be created in "{group}", we don't need the wizard
 ; to ask for a Start Menu folder name:
@@ -34,15 +34,14 @@ ChangesAssociations=yes
 
 ShowLanguageDialog=yes
 
-PrivilegesRequiredOverridesAllowed=commandline dialog
-
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
 Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
 
 [dirs]
-Name: "{app}";  Check: InitializeSetup
+Name: "{app}"; Check: InitializeSetup
+Name: "{app}\web_plugins"; Permissions: users-modify; Check: InitializeSetup
 Name: "{userappdata}\GeoDa\basemap_cache";  Permissions: users-full
 Name: "{userappdata}\GeoDa\lang";  Permissions: users-full
 
@@ -124,18 +123,6 @@ Root: "HKLM"; Subkey: "SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\MAIN\Fea
 ;Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\"; ValueType: String; ValueName: "{app}\GeoDa.exe"; ValueData: "RUNASADMIN"; Flags: uninsdeletekeyifempty uninsdeletevalue; MinVersion: 0,6.1
 
 [Code]
-function GetDefaultDirName(Param: string): string;
-begin
-  if IsAdminLoggedOn then
-  begin
-    Result := ExpandConstant('{pf}\GeoDa Software');
-  end
-    else
-  begin
-    Result := ExpandConstant('{localappdata}\GeoDa');
-  end;
-end;
-
 function IsX64: Boolean;
 begin
   Result := Is64BitInstallMode and (ProcessorArchitecture = paX64);

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -6,12 +6,12 @@ AppSupportURL=https://spatial.uchiago.edu/
 AppUpdatesURL=https://spatial.uchiago.edu/
 AppSupportPhone=(480)965-7533
 AppVersion=1.20
-DefaultDirName={pf}\GeoDa Software
+DefaultDirName={localappdata}\GeoDa
 DefaultGroupName=GeoDa Software
 ; Since no icons will be created in "{group}", we don't need the wizard
 ; to ask for a Start Menu folder name:
 ;DisableProgramGroupPage=yes
-UninstallDisplayIcon={userappdata}\GeoDa.exe
+UninstallDisplayIcon={localappdata}\GeoDa\GeoDa.exe
 Compression=lzma2
 SolidCompression=yes
 OutputDir=..\..
@@ -40,74 +40,74 @@ Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
 Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
 
 [dirs]
-Name: "{userappdata}";  Permissions: users-full; Check: InitializeSetup
-Name: "{userappdata}\basemap_cache";  Permissions: users-full
-Name: "{userappdata}\lang";  Permissions: users-full
-Name: "{userappdata}\proj";  Permissions: users-full
+Name: "{localappdata}\GeoDa";  Permissions: users-full; Check: InitializeSetup
+Name: "{localappdata}\GeoDa\basemap_cache";  Permissions: users-full
+Name: "{localappdata}\GeoDa\lang";  Permissions: users-full
+Name: "{localappdata}\GeoDa\proj";  Permissions: users-full
 
 [Files]
-Source: "..\..\Release\GeoDa.exe"; DestDir: "{userappdata}"; DestName: "GeoDa.exe"; Check: IsX64
-Source: "..\..\..\CommonDistFiles\GeoDa.ico"; DestDir: "{userappdata}"
-Source: "..\..\..\CommonDistFiles\copyright.txt"; DestDir: "{userappdata}"
-Source: "..\..\..\CommonDistFiles\GPLv3.txt"; DestDir: "{userappdata}"
-Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{userappdata}"
-Source: "..\..\..\CommonDistFiles\geoda_prefs.sqlite"; DestDir: "{userappdata}"
-Source: "..\..\..\CommonDistFiles\geoda_prefs.json"; DestDir: "{userappdata}"
-Source: "..\..\..\CommonDistFiles\web_plugins\*"; DestDir: "{userappdata}\web_plugins"; Flags: recursesubdirs
-Source: "..\..\..\CommonDistFiles\proj\*"; DestDir: "{userappdata}\proj"; Flags: recursesubdirs
+Source: "..\..\Release\GeoDa.exe"; DestDir: "{localappdata}\GeoDa"; DestName: "GeoDa.exe"; Check: IsX64
+Source: "..\..\..\CommonDistFiles\GeoDa.ico"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\copyright.txt"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\GPLv3.txt"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\geoda_prefs.sqlite"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\geoda_prefs.json"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\web_plugins\*"; DestDir: "{localappdata}\GeoDa\web_plugins"; Flags: recursesubdirs
+Source: "..\..\..\CommonDistFiles\proj\*"; DestDir: "{localappdata}\GeoDa\proj"; Flags: recursesubdirs
 
-Source: "VC_redist.x64.exe"; DestDir: "{userappdata}"
-Source: "..\..\temp\OpenCL\sdk\bin\x64\OpenCL.dll"; DestDir: "{userappdata}"
-Source: "..\..\temp\wxWidgets\lib\vc_x64_dll\wxmsw314u_vc_custom.dll"; DestDir: "{userappdata}"
-Source: "..\..\temp\wxWidgets\lib\vc_x64_dll\wxmsw314u_gl_vc_custom.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\expat.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\freexl.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\gdal302.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\geos.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\geos_c.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\iconv.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\libcrypto-1_1-x64.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\libcurl.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\libmysql.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\libpq.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\libssl-1_1-x64.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\libxml2.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\openjp2.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\proj.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\proj_6_1.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\spatialite.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\sqlite3.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\xerces-c_3_2.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\zlib1.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\gdal\plugins\ogr_OCI.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_PG.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_MSSQLSpatial.dll"; DestDir: "{userappdata}"
-Source: "..\..\libraries\bin\gdal\plugins-external\ogr_FileGDB.dll"; DestDir: "{userappdata}"
-Source: "..\..\..\..\Algorithms\lisa_kernel.cl"; DestDir: "{userappdata}"
-Source: "..\..\..\..\internationalization\lang\*"; DestDir: "{userappdata}\lang"; Flags: recursesubdirs
-Source: "..\..\libraries\bin\gdal-data\*"; DestDir: "{userappdata}\data"; Flags: recursesubdirs
+Source: "VC_redist.x64.exe"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\temp\OpenCL\sdk\bin\x64\OpenCL.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\temp\wxWidgets\lib\vc_x64_dll\wxmsw314u_vc_custom.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\temp\wxWidgets\lib\vc_x64_dll\wxmsw314u_gl_vc_custom.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\expat.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\freexl.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\gdal302.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\geos.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\geos_c.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\iconv.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libcrypto-1_1-x64.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libcurl.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libmysql.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libpq.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libssl-1_1-x64.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\libxml2.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\openjp2.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\proj.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\proj_6_1.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\spatialite.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\sqlite3.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\xerces-c_3_2.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\zlib1.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\gdal\plugins\ogr_OCI.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_PG.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_MSSQLSpatial.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\libraries\bin\gdal\plugins-external\ogr_FileGDB.dll"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\..\Algorithms\lisa_kernel.cl"; DestDir: "{localappdata}\GeoDa"
+Source: "..\..\..\..\internationalization\lang\*"; DestDir: "{localappdata}\GeoDa\lang"; Flags: recursesubdirs
+Source: "..\..\libraries\bin\gdal-data\*"; DestDir: "{localappdata}\GeoDa\data"; Flags: recursesubdirs
 
-;Source: "Readme.txt"; DestDir: "{userappdata}"; Flags: isreadme
+;Source: "Readme.txt"; DestDir: "{localappdata}\GeoDa"; Flags: isreadme
 
 [Icons]
-Name: "{group}\GeoDa"; Filename: "{userappdata}\GeoDa.exe"
-;Name: "{group}\GeoDa"; Filename: "{userappdata}\run_geoda.bat"; IconFilename: "{userappdata}\GeoDa.ico"
+Name: "{group}\GeoDa"; Filename: "{localappdata}\GeoDa\GeoDa.exe"
+;Name: "{group}\GeoDa"; Filename: "{localappdata}\GeoDa\run_geoda.bat"; IconFilename: "{localappdata}\GeoDa\GeoDa.ico"
 Name: "{group}\Uninstall"; Filename: "{uninstallexe}"
-Name: "{commondesktop}\GeoDa"; Filename: "{userappdata}\GeoDa.exe"
-;Name: "{commondesktop}\GeoDa"; Filename: "{userappdata}\run_geoda.bat"; IconFilename: "{userappdata}\GeoDa.ico"
+Name: "{commondesktop}\GeoDa"; Filename: "{localappdata}\GeoDa\GeoDa.exe"
+;Name: "{commondesktop}\GeoDa"; Filename: "{localappdata}\GeoDa\run_geoda.bat"; IconFilename: "{localappdata}\GeoDa\GeoDa.ico"
 
 [Registry]
 ; set PATH
 ; set GEODA_GDAL_DATA
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{userappdata}\data"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{localappdata}\GeoDa\data"; Flags: preservestringtype uninsdeletevalue
 ; set GEODA_OGR_DRIVER_PATH
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{userappdata}"; Flags: preservestringtype uninsdeletevalue
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{userappdata}\proj"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{localappdata}\GeoDa"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{localappdata}\GeoDa\proj"; Flags: preservestringtype uninsdeletevalue
 
 Root: HKCR; Subkey: ".gda"; ValueType: string; ValueName: ""; ValueData: "GeoDaProjectFile"; Flags: uninsdeletevalue
 Root: HKCR; Subkey: "GeoDaProjectFile"; ValueType: string; ValueName: ""; ValueData: "GeoDa Project File"; Flags: uninsdeletekey
-Root: HKCR; Subkey: "GeoDaProjectFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{userappdata}\GeoDa.exe,0"
-Root: HKCR; Subkey: "GeoDaProjectFile\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{userappdata}\GeoDa.exe"" ""%1"""
+Root: HKCR; Subkey: "GeoDaProjectFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{localappdata}\GeoDa\GeoDa.exe,0"
+Root: HKCR; Subkey: "GeoDaProjectFile\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{localappdata}\GeoDa\GeoDa.exe"" ""%1"""
 
 ; set Browser Emulation for wxWebView to IE 11.  IE 10 or earlier does not work with current D3
 Root: "HKCU"; Subkey: "Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName:"GeoDa.exe"; ValueData:"$2AF9"
@@ -118,7 +118,7 @@ Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Internet Explorer\MAIN\FeatureControl\
 ;64 Bit Mode
 Root: "HKLM"; Subkey: "SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName: "GeoDa.exe"; ValueData: "$2AF9"; Check: IsWin64
 ;run as admin
-;Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\"; ValueType: String; ValueName: "{userappdata}\GeoDa.exe"; ValueData: "RUNASADMIN"; Flags: uninsdeletekeyifempty uninsdeletevalue; MinVersion: 0,6.1
+;Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\"; ValueType: String; ValueName: "{localappdata}\GeoDa\GeoDa.exe"; ValueData: "RUNASADMIN"; Flags: uninsdeletekeyifempty uninsdeletevalue; MinVersion: 0,6.1
 
 [Code]
 function IsX64: Boolean;
@@ -243,8 +243,8 @@ begin
 end;
 
 [INI]
-Filename: "{userappdata}\lang\config.ini"; Section: "Translation"; Key: "Language"; String: {code:getLangCode|{userappdata}}
+Filename: "{localappdata}\GeoDa\lang\config.ini"; Section: "Translation"; Key: "Language"; String: {code:getLangCode|{localappdata}\GeoDa}
 
 [Run]
-Filename: {userappdata}\VC_redist.x64.exe; StatusMsg: Installing Visual C++ Redistributable for Visual Studio 2019 (14.28.29913.0)...; Check: VCRedistNeedsInstall
+Filename: {localappdata}\GeoDa\VC_redist.x64.exe; StatusMsg: Installing Visual C++ Redistributable for Visual Studio 2019 (14.28.29913.0)...; Check: VCRedistNeedsInstall
 

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -50,6 +50,7 @@ Source: "..\..\..\CommonDistFiles\GeoDa.ico"; DestDir: "{app}"
 Source: "..\..\..\CommonDistFiles\copyright.txt"; DestDir: "{app}"
 Source: "..\..\..\CommonDistFiles\GPLv3.txt"; DestDir: "{app}"
 Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{userappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{app}"
 Source: "..\..\..\CommonDistFiles\geoda_prefs.sqlite"; DestDir: "{app}"
 Source: "..\..\..\CommonDistFiles\geoda_prefs.json"; DestDir: "{app}"
 Source: "..\..\..\CommonDistFiles\web_plugins\*"; DestDir: "{app}\web_plugins"; Flags: recursesubdirs
@@ -84,6 +85,7 @@ Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_MSSQLSpatial.dll"; DestDi
 Source: "..\..\libraries\bin\gdal\plugins-external\ogr_FileGDB.dll"; DestDir: "{app}"
 Source: "..\..\..\..\Algorithms\lisa_kernel.cl"; DestDir: "{app}"
 Source: "..\..\..\..\internationalization\lang\*"; DestDir: "{app}\lang"; Flags: recursesubdirs
+Source: "..\..\..\..\internationalization\lang\config.ini"; DestDir: "{userappdata}\GeoDa\lang"
 Source: "..\..\libraries\bin\gdal-data\*"; DestDir: "{app}\data"; Flags: recursesubdirs
 
 ;Source: "Readme.txt"; DestDir: "{app}"; Flags: isreadme

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -6,12 +6,12 @@ AppSupportURL=https://spatial.uchiago.edu/
 AppUpdatesURL=https://spatial.uchiago.edu/
 AppSupportPhone=(480)965-7533
 AppVersion=1.20
-DefaultDirName={localappdata}\GeoDa
+DefaultDirName={pf}\GeoDa Software
 DefaultGroupName=GeoDa Software
 ; Since no icons will be created in "{group}", we don't need the wizard
 ; to ask for a Start Menu folder name:
 ;DisableProgramGroupPage=yes
-UninstallDisplayIcon={localappdata}\GeoDa\GeoDa.exe
+UninstallDisplayIcon={app}\GeoDa.exe
 Compression=lzma2
 SolidCompression=yes
 OutputDir=..\..
@@ -40,74 +40,73 @@ Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
 Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
 
 [dirs]
-Name: "{localappdata}\GeoDa";  Permissions: users-full; Check: InitializeSetup
-Name: "{localappdata}\GeoDa\basemap_cache";  Permissions: users-full
-Name: "{localappdata}\GeoDa\lang";  Permissions: users-full
-Name: "{localappdata}\GeoDa\proj";  Permissions: users-full
+Name: "{app}";  Permissions: everyone-full; Check: InitializeSetup
+Name: "{userappdata}\GeoDa\basemap_cache";  Permissions: users-full
+Name: "{userappdata}\GeoDa\lang";  Permissions: users-full
 
 [Files]
-Source: "..\..\Release\GeoDa.exe"; DestDir: "{localappdata}\GeoDa"; DestName: "GeoDa.exe"; Check: IsX64
-Source: "..\..\..\CommonDistFiles\GeoDa.ico"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\copyright.txt"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\GPLv3.txt"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\geoda_prefs.sqlite"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\geoda_prefs.json"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\CommonDistFiles\web_plugins\*"; DestDir: "{localappdata}\GeoDa\web_plugins"; Flags: recursesubdirs
-Source: "..\..\..\CommonDistFiles\proj\*"; DestDir: "{localappdata}\GeoDa\proj"; Flags: recursesubdirs
+Source: "..\..\Release\GeoDa.exe"; DestDir: "{app}"; DestName: "GeoDa.exe"; Check: IsX64
+Source: "..\..\..\CommonDistFiles\GeoDa.ico"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\copyright.txt"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\GPLv3.txt"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{userappdata}\GeoDa"
+Source: "..\..\..\CommonDistFiles\geoda_prefs.sqlite"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\geoda_prefs.json"; DestDir: "{app}"
+Source: "..\..\..\CommonDistFiles\web_plugins\*"; DestDir: "{app}\web_plugins"; Flags: recursesubdirs
+Source: "..\..\..\CommonDistFiles\proj\*"; DestDir: "{app}\proj"; Flags: recursesubdirs
 
-Source: "VC_redist.x64.exe"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\temp\OpenCL\sdk\bin\x64\OpenCL.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\temp\wxWidgets\lib\vc_x64_dll\wxmsw314u_vc_custom.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\temp\wxWidgets\lib\vc_x64_dll\wxmsw314u_gl_vc_custom.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\expat.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\freexl.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\gdal302.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\geos.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\geos_c.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\iconv.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libcrypto-1_1-x64.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libcurl.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libmysql.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libpq.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libssl-1_1-x64.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\libxml2.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\openjp2.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\proj.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\proj_6_1.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\spatialite.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\sqlite3.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\xerces-c_3_2.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\zlib1.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\gdal\plugins\ogr_OCI.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_PG.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_MSSQLSpatial.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\libraries\bin\gdal\plugins-external\ogr_FileGDB.dll"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\..\Algorithms\lisa_kernel.cl"; DestDir: "{localappdata}\GeoDa"
-Source: "..\..\..\..\internationalization\lang\*"; DestDir: "{localappdata}\GeoDa\lang"; Flags: recursesubdirs
-Source: "..\..\libraries\bin\gdal-data\*"; DestDir: "{localappdata}\GeoDa\data"; Flags: recursesubdirs
+Source: "VC_redist.x64.exe"; DestDir: "{app}"
+Source: "..\..\temp\OpenCL\sdk\bin\x64\OpenCL.dll"; DestDir: "{app}"
+Source: "..\..\temp\wxWidgets\lib\vc_x64_dll\wxmsw314u_vc_custom.dll"; DestDir: "{app}"
+Source: "..\..\temp\wxWidgets\lib\vc_x64_dll\wxmsw314u_gl_vc_custom.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\expat.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\freexl.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\gdal302.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\geos.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\geos_c.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\iconv.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libcrypto-1_1-x64.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libcurl.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libmysql.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libpq.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libssl-1_1-x64.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\libxml2.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\openjp2.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\proj.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\proj_6_1.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\spatialite.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\sqlite3.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\xerces-c_3_2.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\zlib1.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\gdal\plugins\ogr_OCI.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_PG.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_MSSQLSpatial.dll"; DestDir: "{app}"
+Source: "..\..\libraries\bin\gdal\plugins-external\ogr_FileGDB.dll"; DestDir: "{app}"
+Source: "..\..\..\..\Algorithms\lisa_kernel.cl"; DestDir: "{app}"
+Source: "..\..\..\..\internationalization\lang\*"; DestDir: "{app}\lang"; Flags: recursesubdirs
+Source: "..\..\libraries\bin\gdal-data\*"; DestDir: "{app}\data"; Flags: recursesubdirs
 
-;Source: "Readme.txt"; DestDir: "{localappdata}\GeoDa"; Flags: isreadme
+;Source: "Readme.txt"; DestDir: "{app}"; Flags: isreadme
 
 [Icons]
-Name: "{group}\GeoDa"; Filename: "{localappdata}\GeoDa\GeoDa.exe"
-;Name: "{group}\GeoDa"; Filename: "{localappdata}\GeoDa\run_geoda.bat"; IconFilename: "{localappdata}\GeoDa\GeoDa.ico"
+Name: "{group}\GeoDa"; Filename: "{app}\GeoDa.exe"
+;Name: "{group}\GeoDa"; Filename: "{app}\run_geoda.bat"; IconFilename: "{app}\GeoDa.ico"
 Name: "{group}\Uninstall"; Filename: "{uninstallexe}"
-Name: "{commondesktop}\GeoDa"; Filename: "{localappdata}\GeoDa\GeoDa.exe"
-;Name: "{commondesktop}\GeoDa"; Filename: "{localappdata}\GeoDa\run_geoda.bat"; IconFilename: "{localappdata}\GeoDa\GeoDa.ico"
+Name: "{commondesktop}\GeoDa"; Filename: "{app}\GeoDa.exe"
+;Name: "{commondesktop}\GeoDa"; Filename: "{app}\run_geoda.bat"; IconFilename: "{app}\GeoDa.ico"
 
 [Registry]
 ; set PATH
 ; set GEODA_GDAL_DATA
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{localappdata}\GeoDa\data"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{app}\data"; Flags: preservestringtype uninsdeletevalue
 ; set GEODA_OGR_DRIVER_PATH
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{localappdata}\GeoDa"; Flags: preservestringtype uninsdeletevalue
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{localappdata}\GeoDa\proj"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{app}"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{app}\proj"; Flags: preservestringtype uninsdeletevalue
 
 Root: HKCR; Subkey: ".gda"; ValueType: string; ValueName: ""; ValueData: "GeoDaProjectFile"; Flags: uninsdeletevalue
 Root: HKCR; Subkey: "GeoDaProjectFile"; ValueType: string; ValueName: ""; ValueData: "GeoDa Project File"; Flags: uninsdeletekey
-Root: HKCR; Subkey: "GeoDaProjectFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{localappdata}\GeoDa\GeoDa.exe,0"
-Root: HKCR; Subkey: "GeoDaProjectFile\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{localappdata}\GeoDa\GeoDa.exe"" ""%1"""
+Root: HKCR; Subkey: "GeoDaProjectFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\GeoDa.exe,0"
+Root: HKCR; Subkey: "GeoDaProjectFile\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\GeoDa.exe"" ""%1"""
 
 ; set Browser Emulation for wxWebView to IE 11.  IE 10 or earlier does not work with current D3
 Root: "HKCU"; Subkey: "Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName:"GeoDa.exe"; ValueData:"$2AF9"
@@ -118,7 +117,7 @@ Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Internet Explorer\MAIN\FeatureControl\
 ;64 Bit Mode
 Root: "HKLM"; Subkey: "SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName: "GeoDa.exe"; ValueData: "$2AF9"; Check: IsWin64
 ;run as admin
-;Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\"; ValueType: String; ValueName: "{localappdata}\GeoDa\GeoDa.exe"; ValueData: "RUNASADMIN"; Flags: uninsdeletekeyifempty uninsdeletevalue; MinVersion: 0,6.1
+;Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\"; ValueType: String; ValueName: "{app}\GeoDa.exe"; ValueData: "RUNASADMIN"; Flags: uninsdeletekeyifempty uninsdeletevalue; MinVersion: 0,6.1
 
 [Code]
 function IsX64: Boolean;
@@ -243,8 +242,8 @@ begin
 end;
 
 [INI]
-Filename: "{localappdata}\GeoDa\lang\config.ini"; Section: "Translation"; Key: "Language"; String: {code:getLangCode|{localappdata}\GeoDa}
+Filename: "{userappdata}\GeoDa\lang\config.ini"; Section: "Translation"; Key: "Language"; String: {code:getLangCode|{userappdata}\GeoDa}
 
 [Run]
-Filename: {localappdata}\GeoDa\VC_redist.x64.exe; StatusMsg: Installing Visual C++ Redistributable for Visual Studio 2019 (14.28.29913.0)...; Check: VCRedistNeedsInstall
+Filename: {app}\VC_redist.x64.exe; StatusMsg: Installing Visual C++ Redistributable for Visual Studio 2019 (14.28.29913.0)...; Check: VCRedistNeedsInstall
 

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -1,0 +1,250 @@
+[Setup]
+AppName=GeoDa                                                      
+AppPublisher=GeoDa Center
+AppPublisherURL=https://spatial.uchiago.edu/
+AppSupportURL=https://spatial.uchiago.edu/
+AppUpdatesURL=https://spatial.uchiago.edu/
+AppSupportPhone=(480)965-7533
+AppVersion=1.20
+DefaultDirName={pf}\GeoDa Software
+DefaultGroupName=GeoDa Software
+; Since no icons will be created in "{group}", we don't need the wizard
+; to ask for a Start Menu folder name:
+;DisableProgramGroupPage=yes
+UninstallDisplayIcon={userappdata}\GeoDa.exe
+Compression=lzma2
+SolidCompression=yes
+OutputDir=..\..
+OutputBaseFilename=GeoDa_1.20_win7+x64_Setup
+;OutputDir=userdocs:Inno Setup Examples Output
+
+; "ArchitecturesAllowed=x64" specifies that Setup cannot run on
+; anything but x64.
+; Note: We don't set ProcessorsAllowed because we want this
+; installation to run on all architectures (including Itanium,
+; since it's capable of running 32-bit code too).
+ArchitecturesAllowed=x64
+
+; "ArchitecturesInstallIn64BitMode=x64" requests that the install be
+; done in "64-bit mode" on x64, meaning it should use the native
+; 64-bit Program Files directory and the 64-bit view of the registry.
+ArchitecturesInstallIn64BitMode=x64
+
+ChangesAssociations=yes
+
+ShowLanguageDialog=yes
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
+Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
+
+[dirs]
+Name: "{userappdata}";  Permissions: users-full; Check: InitializeSetup
+Name: "{userappdata}\basemap_cache";  Permissions: users-full
+Name: "{userappdata}\lang";  Permissions: users-full
+Name: "{userappdata}\proj";  Permissions: users-full
+
+[Files]
+Source: "..\..\Release\GeoDa.exe"; DestDir: "{userappdata}"; DestName: "GeoDa.exe"; Check: IsX64
+Source: "..\..\..\CommonDistFiles\GeoDa.ico"; DestDir: "{userappdata}"
+Source: "..\..\..\CommonDistFiles\copyright.txt"; DestDir: "{userappdata}"
+Source: "..\..\..\CommonDistFiles\GPLv3.txt"; DestDir: "{userappdata}"
+Source: "..\..\..\CommonDistFiles\cache.sqlite"; DestDir: "{userappdata}"
+Source: "..\..\..\CommonDistFiles\geoda_prefs.sqlite"; DestDir: "{userappdata}"
+Source: "..\..\..\CommonDistFiles\geoda_prefs.json"; DestDir: "{userappdata}"
+Source: "..\..\..\CommonDistFiles\web_plugins\*"; DestDir: "{userappdata}\web_plugins"; Flags: recursesubdirs
+Source: "..\..\..\CommonDistFiles\proj\*"; DestDir: "{userappdata}\proj"; Flags: recursesubdirs
+
+Source: "VC_redist.x64.exe"; DestDir: "{userappdata}"
+Source: "..\..\temp\OpenCL\sdk\bin\x64\OpenCL.dll"; DestDir: "{userappdata}"
+Source: "..\..\temp\wxWidgets\lib\vc_x64_dll\wxmsw314u_vc_custom.dll"; DestDir: "{userappdata}"
+Source: "..\..\temp\wxWidgets\lib\vc_x64_dll\wxmsw314u_gl_vc_custom.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\expat.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\freexl.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\gdal302.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\geos.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\geos_c.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\iconv.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\libcrypto-1_1-x64.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\libcurl.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\libmysql.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\libpq.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\libssl-1_1-x64.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\libxml2.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\openjp2.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\proj.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\proj_6_1.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\spatialite.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\sqlite3.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\xerces-c_3_2.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\zlib1.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\gdal\plugins\ogr_OCI.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_PG.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\gdal\plugins-optional\ogr_MSSQLSpatial.dll"; DestDir: "{userappdata}"
+Source: "..\..\libraries\bin\gdal\plugins-external\ogr_FileGDB.dll"; DestDir: "{userappdata}"
+Source: "..\..\..\..\Algorithms\lisa_kernel.cl"; DestDir: "{userappdata}"
+Source: "..\..\..\..\internationalization\lang\*"; DestDir: "{userappdata}\lang"; Flags: recursesubdirs
+Source: "..\..\libraries\bin\gdal-data\*"; DestDir: "{userappdata}\data"; Flags: recursesubdirs
+
+;Source: "Readme.txt"; DestDir: "{userappdata}"; Flags: isreadme
+
+[Icons]
+Name: "{group}\GeoDa"; Filename: "{userappdata}\GeoDa.exe"
+;Name: "{group}\GeoDa"; Filename: "{userappdata}\run_geoda.bat"; IconFilename: "{userappdata}\GeoDa.ico"
+Name: "{group}\Uninstall"; Filename: "{uninstallexe}"
+Name: "{commondesktop}\GeoDa"; Filename: "{userappdata}\GeoDa.exe"
+;Name: "{commondesktop}\GeoDa"; Filename: "{userappdata}\run_geoda.bat"; IconFilename: "{userappdata}\GeoDa.ico"
+
+[Registry]
+; set PATH
+; set GEODA_GDAL_DATA
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{userappdata}\data"; Flags: preservestringtype uninsdeletevalue
+; set GEODA_OGR_DRIVER_PATH
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{userappdata}"; Flags: preservestringtype uninsdeletevalue
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{userappdata}\proj"; Flags: preservestringtype uninsdeletevalue
+
+Root: HKCR; Subkey: ".gda"; ValueType: string; ValueName: ""; ValueData: "GeoDaProjectFile"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "GeoDaProjectFile"; ValueType: string; ValueName: ""; ValueData: "GeoDa Project File"; Flags: uninsdeletekey
+Root: HKCR; Subkey: "GeoDaProjectFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{userappdata}\GeoDa.exe,0"
+Root: HKCR; Subkey: "GeoDaProjectFile\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{userappdata}\GeoDa.exe"" ""%1"""
+
+; set Browser Emulation for wxWebView to IE 11.  IE 10 or earlier does not work with current D3
+Root: "HKCU"; Subkey: "Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName:"GeoDa.exe"; ValueData:"$2AF9"
+
+;Local Machine
+Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName: "GeoDa.exe"; ValueData: "$2AF9"
+
+;64 Bit Mode
+Root: "HKLM"; Subkey: "SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BROWSER_EMULATION"; ValueType: dword; ValueName: "GeoDa.exe"; ValueData: "$2AF9"; Check: IsWin64
+;run as admin
+;Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\"; ValueType: String; ValueName: "{userappdata}\GeoDa.exe"; ValueData: "RUNASADMIN"; Flags: uninsdeletekeyifempty uninsdeletevalue; MinVersion: 0,6.1
+
+[Code]
+function IsX64: Boolean;
+begin
+  Result := Is64BitInstallMode and (ProcessorArchitecture = paX64);
+end;
+
+function IsIA64: Boolean;
+begin
+  Result := Is64BitInstallMode and (ProcessorArchitecture = paIA64);
+end;
+
+function IsOtherArch: Boolean;
+begin
+  Result := not IsX64 and not IsIA64;
+end;
+
+function VCRedistNeedsInstall: Boolean;
+begin
+  Result := not RegKeyExists(HKLM,'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{855e31d2-9031-46e1-b06d-c9d7777deefb}');
+end;
+
+function GetUninstallString: string;
+var
+  sUnInstPath: string;
+  sUnInstallString: String;
+begin
+  Result := '';
+  sUnInstPath := ExpandConstant('Software\Microsoft\Windows\CurrentVersion\Uninstall\GeoDa_is1'); //Your App GUID/ID
+  sUnInstallString := '';
+  if not RegQueryStringValue(HKLM, sUnInstPath, 'UninstallString', sUnInstallString) then
+    RegQueryStringValue(HKCU, sUnInstPath, 'UninstallString', sUnInstallString);
+  Result := sUnInstallString;
+end;
+
+function IsUpgrade: Boolean;
+begin
+  Result := (GetUninstallString() <> '');
+end;
+
+function InitializeSetup: Boolean;
+var
+  V: Integer;
+  iResultCode: Integer;
+  sUnInstallString: string;
+begin
+  Result := True; // in case when no previous version is found
+  if RegValueExists(HKEY_LOCAL_MACHINE,'Software\Microsoft\Windows\CurrentVersion\Uninstall\GeoDa_is1', 'UninstallString') then  //Your App GUID/ID
+  begin
+    V := MsgBox(ExpandConstant('An old version of GeoDa was detected. Please uninstall it before continuing.'), mbInformation, MB_YESNO); //Custom Message if App installed
+    if V = IDYES then
+    begin
+      sUnInstallString := GetUninstallString();
+      sUnInstallString :=  RemoveQuotes(sUnInstallString);
+      Exec(ExpandConstant(sUnInstallString), '', '', SW_SHOW, ewWaitUntilTerminated, iResultCode);
+      Result := True; //if you want to proceed after uninstall
+      //Exit; //if you want to quit after uninstall
+    end
+    else
+      Result := False; //when older version present and not uninstalled
+  end;
+end;
+
+var
+  Button: TNewButton;
+  ComboBox: TNewComboBox;
+  CustomPage: TWizardPage;     
+  langCode: string;
+
+procedure ComboBoxChange(Sender: TObject);
+begin
+  case ComboBox.ItemIndex of
+    0:
+    begin
+      langCode := '58';
+    end;
+    1:
+    begin
+      langCode := '45';   // chinese
+    end;
+    2:
+    begin
+      langCode := '179';  // spanish
+    end;
+    3:
+    begin
+      langCode := '159';  // russian
+    end;
+  end;
+end;
+
+procedure InitializeWizard;
+var
+  DescLabel: TLabel;
+begin
+  CustomPage := CreateCustomPage(wpSelectDir, 'Language Selection', 'Please select a language for GeoDa');
+
+  DescLabel := TLabel.Create(WizardForm);
+  DescLabel.Parent := CustomPage.Surface;
+  DescLabel.Left := 0;
+  DescLabel.Top := 0;
+  DescLabel.Caption := '';
+
+  ComboBox := TNewComboBox.Create(WizardForm);
+  ComboBox.Parent := CustomPage.Surface;
+  ComboBox.Left := 0;
+  ComboBox.Top := DescLabel.Top + DescLabel.Height + 6;  
+  ComboBox.Width := 220;
+  ComboBox.Style := csDropDownList;
+  ComboBox.Items.Add('English');
+  ComboBox.Items.Add('Chinese (Simplified)');
+  ComboBox.Items.Add('Spanish');
+  ComboBox.Items.Add('Russian');
+  ComboBox.ItemIndex := 0;
+  ComboBox.OnChange := @ComboBoxChange;
+  langCode := '58';
+end;
+
+function getLangCode(Param: String): String;
+begin
+  Result :=  langCode;
+end;
+
+[INI]
+Filename: "{userappdata}\lang\config.ini"; Section: "Translation"; Key: "Language"; String: {code:getLangCode|{userappdata}}
+
+[Run]
+Filename: {userappdata}\VC_redist.x64.exe; StatusMsg: Installing Visual C++ Redistributable for Visual Studio 2019 (14.28.29913.0)...; Check: VCRedistNeedsInstall
+

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -40,10 +40,9 @@ Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
 Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
 
 [dirs]
-Name: "{app}"; Check: InitializeSetup
-Name: "{app}\web_plugins"; Permissions: users-modify; Check: InitializeSetup
-Name: "{userappdata}\GeoDa\basemap_cache";  Permissions: users-full
-Name: "{userappdata}\GeoDa\lang";  Permissions: users-full
+Name: "{app}"; Permissions: users-modify; Check: InitializeSetup
+Name: "{userappdata}\GeoDa\basemap_cache";  Permissions: users-modify
+Name: "{userappdata}\GeoDa\lang";  Permissions: users-modify
 
 [Files]
 Source: "..\..\Release\GeoDa.exe"; DestDir: "{app}"; DestName: "GeoDa.exe"; Check: IsX64

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -40,7 +40,7 @@ Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
 Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
 
 [dirs]
-Name: "{app}"; Permissions: users-modify; Check: InitializeSetup
+Name: "{app}"; Check: InitializeSetup
 Name: "{userappdata}\GeoDa\basemap_cache";  Permissions: users-modify
 Name: "{userappdata}\GeoDa\lang";  Permissions: users-modify
 

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -6,7 +6,7 @@ AppSupportURL=https://spatial.uchiago.edu/
 AppUpdatesURL=https://spatial.uchiago.edu/
 AppSupportPhone=(480)965-7533
 AppVersion=1.20
-DefaultDirName={pf}\GeoDa Software
+DefaultDirName={code:GetDefaultDirName}
 DefaultGroupName=GeoDa Software
 ; Since no icons will be created in "{group}", we don't need the wizard
 ; to ask for a Start Menu folder name:
@@ -34,13 +34,15 @@ ChangesAssociations=yes
 
 ShowLanguageDialog=yes
 
+PrivilegesRequiredOverridesAllowed=commandline dialog
+
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
 Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
 
 [dirs]
-Name: "{app}";  Permissions: everyone-full; Check: InitializeSetup
+Name: "{app}";  Check: InitializeSetup
 Name: "{userappdata}\GeoDa\basemap_cache";  Permissions: users-full
 Name: "{userappdata}\GeoDa\lang";  Permissions: users-full
 
@@ -122,6 +124,18 @@ Root: "HKLM"; Subkey: "SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\MAIN\Fea
 ;Root: "HKLM"; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\"; ValueType: String; ValueName: "{app}\GeoDa.exe"; ValueData: "RUNASADMIN"; Flags: uninsdeletekeyifempty uninsdeletevalue; MinVersion: 0,6.1
 
 [Code]
+function GetDefaultDirName(Param: string): string;
+begin
+  if IsAdminLoggedOn then
+  begin
+    Result := ExpandConstant('{pf}\GeoDa Software');
+  end
+    else
+  begin
+    Result := ExpandConstant('{localappdata}\GeoDa');
+  end;
+end;
+
 function IsX64: Boolean;
 begin
   Result := Is64BitInstallMode and (ProcessorArchitecture = paX64);

--- a/DialogTools/PreferenceDlg.cpp
+++ b/DialogTools/PreferenceDlg.cpp
@@ -923,15 +923,8 @@ void PreferenceDlg::OnChooseLanguage(wxCommandEvent& ev)
     sel_str << GdaConst::gda_ui_language;
     OGRDataAdapter::GetInstance().AddEntry("gda_ui_language", sel_str);
     
-    // also update the lang/config.ini content
-    wxString exePath = wxStandardPaths::Get().GetExecutablePath();
-    wxFileName exeFile(exePath);
-    wxString exeDir = exeFile.GetPathWithSep();
-#ifdef __WXMAC__
-    wxString configPath = exeDir + "../Resources/lang/config.ini";
-#else
-    wxString configPath = exeDir + "lang" + wxFileName::GetPathSeparator() + "config.ini";
-#endif
+    // also update the lang/config.ini content    
+    wxString configPath = GenUtils::GetLangSearchPath() + wxFileName::GetPathSeparator() + "config.ini";
     wxConfigBase * config = new wxFileConfig("GeoDa", wxEmptyString, configPath);
     
     if (lan_sel > 0) {

--- a/DialogTools/ReportBugDlg.cpp
+++ b/DialogTools/ReportBugDlg.cpp
@@ -337,8 +337,7 @@ bool ReportBugDlg::CreateIssue(wxString title, wxString body)
 {
 	body.Replace("\n", "\\n");
 	// get log file to body
-	wxString logger_path;
-	logger_path << GenUtils::GetSamplesDir() << "logger.txt";
+	wxString logger_path = GenUtils::GetLoggerPath();
     
 	body << "\\n";
     

--- a/GenUtils.cpp
+++ b/GenUtils.cpp
@@ -2395,7 +2395,17 @@ wxString GenUtils::GetBasemapDir()
 #elif __WXMAC__
     return GetExeDir() + "../Resources/basemap_cache";
 #else
-    return GetExeDir() + "basemap_cache";
+    wxString confDir = wxStandardPaths::Get().GetUserConfigDir();
+    // Windows: AppData\Roaming\GeoDa
+    wxString geodaUserDir = confDir + wxFileName::GetPathSeparator() + "GeoDa";
+    if (wxDirExists(geodaUserDir) == false) {
+        wxFileName::Mkdir(geodaUserDir);
+    }
+    wxString basemapDir = geodaUserDir + wxFileName::GetPathSeparator() + "basemap_cache";
+    if (wxDirExists(basemapDir) == false) {
+        wxFileName::Mkdir(basemapDir);
+    }
+    return basemapDir;
 #endif
 }
 
@@ -2417,6 +2427,44 @@ wxString GenUtils::GetCachePath()
 #elif __WXMAC__
     return GetExeDir() + "../Resources/cache.sqlite";
 #else
-    return GetExeDir() + "cache.sqlite";
+    wxString confDir = wxStandardPaths::Get().GetUserConfigDir();
+    // Windows: AppData\Roaming\GeoDa
+    wxString geodaUserDir = confDir + wxFileName::GetPathSeparator() + "GeoDa";
+    if (wxDirExists(geodaUserDir) == false) {
+        wxFileName::Mkdir(geodaUserDir);
+    }
+    wxString cachePath = geodaUserDir + wxFileName::GetPathSeparator() + "cache.sqlite";
+    if (wxFileExists(cachePath) == false) {
+        wxString origCachePath = GetExeDir() + "cache.sqlite";
+        wxCopyFile(origCachePath, cachePath);
+    }
+    return cachePath;
 #endif
+}
+
+wxString GenUtils::GetLangSearchPath()
+{
+#ifdef __WXMAC__
+    wxString search_path = GetExeDir() + "/../Resources/lang";
+#elif __WIN32__
+    wxString confDir = wxStandardPaths::Get().GetUserConfigDir();
+    // Windows: AppData\Roaming\GeoDa
+    wxString geodaUserDir = confDir + wxFileName::GetPathSeparator() + "GeoDa";
+    if (wxDirExists(geodaUserDir) == false) {
+        wxFileName::Mkdir(geodaUserDir);
+    }
+    wxString search_path = geodaUserDir + wxFileName::GetPathSeparator() + "lang";
+    if (wxDirExists(search_path) == false) {
+        wxFileName::Mkdir(search_path);
+    }
+    wxString langPath = search_path + wxFileName::GetPathSeparator() + "config.ini";
+    if (wxFileExists(langPath) == false) {
+        wxString origLangPath = GetExeDir() + "lang" + wxFileName::GetPathSeparator() + "config.ini";
+        wxCopyFile(origLangPath, langPath);
+    }
+#else
+    wxString search_path = GetExeDir() + wxFileName::GetPathSeparator() +  "lang";
+#endif
+    
+    return search_path;
 }

--- a/GenUtils.cpp
+++ b/GenUtils.cpp
@@ -2357,8 +2357,16 @@ wxString GenUtils::GetSamplesDir()
 {
 #ifdef __WXOSX__
     return GetResourceDir();
-#else
+#elif __linux__
     return GetWebPluginsDir();
+#else
+    wxString confDir = wxStandardPaths::Get().GetUserConfigDir();
+    // Windows: AppData\Roaming\GeoDa
+    wxString geodaUserDir = confDir + wxFileName::GetPathSeparator() + "GeoDa";
+    if (wxDirExists(geodaUserDir) == false) {
+        wxFileName::Mkdir(geodaUserDir);
+    }
+    return geodaUserDir;
 #endif
 }
 

--- a/GenUtils.cpp
+++ b/GenUtils.cpp
@@ -2357,8 +2357,17 @@ wxString GenUtils::GetSamplesDir()
 {
 #ifdef __WXOSX__
     return GetResourceDir();
-#elif __linux__
+#else
     return GetWebPluginsDir();
+#endif
+}
+
+wxString GenUtils::GetLoggerPath()
+{
+#ifdef __WXOSX__
+    return GetResourceDir() + "logger.txt";
+#elif __linux__
+    return GetWebPluginsDir() + "logger.txt";
 #else
     wxString confDir = wxStandardPaths::Get().GetUserConfigDir();
     // Windows: AppData\Roaming\GeoDa
@@ -2366,7 +2375,7 @@ wxString GenUtils::GetSamplesDir()
     if (wxDirExists(geodaUserDir) == false) {
         wxFileName::Mkdir(geodaUserDir);
     }
-    return geodaUserDir;
+    return geodaUserDir + wxFileName::GetPathSeparator() + "logger.txt";
 #endif
 }
 

--- a/GenUtils.cpp
+++ b/GenUtils.cpp
@@ -2444,9 +2444,11 @@ wxString GenUtils::GetCachePath()
 
 wxString GenUtils::GetLangSearchPath()
 {
-#ifdef __WXMAC__
+#ifdef __linux__
+    wxString search_path = GetExeDir() + wxFileName::GetPathSeparator() +  "lang";
+#elif __WXMAC__
     wxString search_path = GetExeDir() + "/../Resources/lang";
-#elif __WIN32__
+#else
     wxString confDir = wxStandardPaths::Get().GetUserConfigDir();
     // Windows: AppData\Roaming\GeoDa
     wxString geodaUserDir = confDir + wxFileName::GetPathSeparator() + "GeoDa";
@@ -2462,8 +2464,6 @@ wxString GenUtils::GetLangSearchPath()
         wxString origLangPath = GetExeDir() + "lang" + wxFileName::GetPathSeparator() + "config.ini";
         wxCopyFile(origLangPath, langPath);
     }
-#else
-    wxString search_path = GetExeDir() + wxFileName::GetPathSeparator() +  "lang";
 #endif
     
     return search_path;

--- a/GenUtils.h
+++ b/GenUtils.h
@@ -457,6 +457,7 @@ namespace GenUtils {
     wxString GetUserSamplesDir();
     wxString GetBasemapDir();
     wxString GetCachePath();
+    wxString GetLangSearchPath();
 
     bool less_vectors(const vector<int>& a,const vector<int>& b);
     bool smaller_pair(const std::pair<int, int>& a,

--- a/GenUtils.h
+++ b/GenUtils.h
@@ -458,6 +458,7 @@ namespace GenUtils {
     wxString GetBasemapDir();
     wxString GetCachePath();
     wxString GetLangSearchPath();
+    wxString GetLoggerPath();
 
     bool less_vectors(const vector<int>& a,const vector<int>& b);
     bool smaller_pair(const std::pair<int, int>& a,

--- a/GeoDa.cpp
+++ b/GeoDa.cpp
@@ -274,14 +274,8 @@ bool GdaApp::OnInit(void)
     // load language here: GdaConst::gda_ui_language
     // search_path is the ./lang directory
     // config_path it the exe directory (every user will have a different config file?)
-    wxFileName appFileName(argv[0]);
-    appFileName.Normalize(wxPATH_NORM_DOTS|wxPATH_NORM_ABSOLUTE| wxPATH_NORM_TILDE);
+    wxString search_path = GenUtils::GetLangSearchPath();
     
-#ifdef __WXMAC__
-    wxString search_path = appFileName.GetPath() + "/../Resources/lang";
-#else
-    wxString search_path = appFileName.GetPath() + wxFileName::GetPathSeparator() +  "lang";
-#endif
     // load language from lang/config.ini if user specified any
     wxString config_path = search_path + wxFileName::GetPathSeparator()+ "config.ini";
     bool use_native_config = false;

--- a/GeoDa.cpp
+++ b/GeoDa.cpp
@@ -401,7 +401,7 @@ bool GdaApp::OnInit(void)
     welcome_pos.y += 150;
    
     // Setup new Logger after crash check
-    wxString loggerFile = GenUtils::GetSamplesDir() +"logger.txt";
+    wxString loggerFile = GenUtils::GetLoggerPath();
     
     if (m_pLogFile == NULL) {
 #ifdef __WIN32__


### PR DESCRIPTION
* The main purpose of this new windows installer for Windows7+ is to separate user data stored in e.g. C:\Program Files to %userapp% directory. 
* The "everyone-fullcontrol" permissions on C:\Program Files\GeoDa software have also been removed. (only read and execute)
* So,  the administrator (e.g. in a lab environment) can install GeoDa for all users, which will have their own geoda data under their own %appdata% directory.

See https://github.com/GeoDaCenter/geoda/issues/2349