### PR TITLE
fix: windows dll registry issue

### DIFF
--- a/BuildTools/windows/installer/32bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/32bit/GeoDa-win7+.iss
@@ -1,9 +1,9 @@
 [Setup]
 AppName=GeoDa                                                      
 AppPublisher=GeoDa Center
-AppPublisherURL=https://spatial.uchiago.edu/
-AppSupportURL=https://spatial.uchiago.edu/
-AppUpdatesURL=https://spatial.uchiago.edu/
+AppPublisherURL=https://spatial.uchicago.edu/
+AppSupportURL=https://spatial.uchicago.edu/
+AppUpdatesURL=https://spatial.uchicago.edu/
 AppSupportPhone=(480)965-7533
 AppVersion=1.20
 DefaultDirName={pf}\GeoDa

--- a/BuildTools/windows/installer/32bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/32bit/GeoDa-win7+.iss
@@ -87,10 +87,10 @@ Name: "{commondesktop}\GeoDa"; Filename: "{app}\GeoDa.exe"
 [Registry]
 ; set PATH
 ; set GEODA_GDAL_DATA
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{app}\data"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{app}\data"; Flags: preservestringtype uninsdeletevalue
 ; set GEODA_OGR_DRIVER_PATH
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{app}"; Flags: preservestringtype uninsdeletevalue
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{app}\proj"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{app}"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{app}\proj"; Flags: preservestringtype uninsdeletevalue
 
 Root: HKCR; Subkey: ".gda"; ValueType: string; ValueName: ""; ValueData: "GeoDaProjectFile"; Flags: uninsdeletevalue
 Root: HKCR; Subkey: "GeoDaProjectFile"; ValueType: string; ValueName: ""; ValueData: "GeoDa Project File"; Flags: uninsdeletekey

--- a/BuildTools/windows/installer/32bit/GeoDa.iss
+++ b/BuildTools/windows/installer/32bit/GeoDa.iss
@@ -1,9 +1,9 @@
 [Setup]
 AppName=GeoDa                                                      
 AppPublisher=GeoDa Center
-AppPublisherURL=https://spatial.uchiago.edu/
-AppSupportURL=https://spatial.uchiago.edu/
-AppUpdatesURL=https://spatial.uchiago.edu/
+AppPublisherURL=https://spatial.uchicago.edu/
+AppSupportURL=https://spatial.uchicago.edu/
+AppUpdatesURL=https://spatial.uchicago.edu/
 AppSupportPhone=(480)965-7533
 AppVersion=1.20
 DefaultDirName={pf}\GeoDa Software

--- a/BuildTools/windows/installer/32bit/GeoDa.iss
+++ b/BuildTools/windows/installer/32bit/GeoDa.iss
@@ -86,10 +86,10 @@ Name: "{commondesktop}\GeoDa"; Filename: "{app}\GeoDa.exe"
 [Registry]
 ; set PATH
 ; set GEODA_GDAL_DATA
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{app}\data"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{app}\data"; Flags: preservestringtype uninsdeletevalue
 ; set GEODA_OGR_DRIVER_PATH
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{app}"; Flags: preservestringtype uninsdeletevalue
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{app}\proj"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{app}"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{app}\proj"; Flags: preservestringtype uninsdeletevalue
 
 Root: HKCR; Subkey: ".gda"; ValueType: string; ValueName: ""; ValueData: "GeoDaProjectFile"; Flags: uninsdeletevalue
 Root: HKCR; Subkey: "GeoDaProjectFile"; ValueType: string; ValueName: ""; ValueData: "GeoDa Project File"; Flags: uninsdeletekey

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -1,9 +1,9 @@
 [Setup]
 AppName=GeoDa                                                      
 AppPublisher=GeoDa Center
-AppPublisherURL=https://spatial.uchiago.edu/
-AppSupportURL=https://spatial.uchiago.edu/
-AppUpdatesURL=https://spatial.uchiago.edu/
+AppPublisherURL=https://spatial.uchicago.edu/
+AppSupportURL=https://spatial.uchicago.edu/
+AppUpdatesURL=https://spatial.uchicago.edu/
 AppSupportPhone=(480)965-7533
 AppVersion=1.20
 DefaultDirName={pf}\GeoDa Software

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -100,10 +100,10 @@ Name: "{commondesktop}\GeoDa"; Filename: "{app}\GeoDa.exe"
 [Registry]
 ; set PATH
 ; set GEODA_GDAL_DATA
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{app}\data"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{app}\data"; Flags: preservestringtype uninsdeletevalue
 ; set GEODA_OGR_DRIVER_PATH
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{app}"; Flags: preservestringtype uninsdeletevalue
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{app}\proj"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{app}"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{app}\proj"; Flags: preservestringtype uninsdeletevalue
 
 Root: HKCR; Subkey: ".gda"; ValueType: string; ValueName: ""; ValueData: "GeoDaProjectFile"; Flags: uninsdeletevalue
 Root: HKCR; Subkey: "GeoDaProjectFile"; ValueType: string; ValueName: ""; ValueData: "GeoDa Project File"; Flags: uninsdeletekey

--- a/BuildTools/windows/installer/64bit/GeoDa.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa.iss
@@ -99,10 +99,10 @@ Name: "{commondesktop}\GeoDa"; Filename: "{app}\GeoDa.exe"
 [Registry]
 ; set PATH
 ; set GEODA_GDAL_DATA
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{app}\data"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"GDAL_DATA"; ValueData:"{app}\data"; Flags: preservestringtype uninsdeletevalue
 ; set GEODA_OGR_DRIVER_PATH
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{app}"; Flags: preservestringtype uninsdeletevalue
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{app}\proj"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"OGR_DRIVER_PATH"; ValueData:"{app}"; Flags: preservestringtype uninsdeletevalue
+; Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"PROJ_LIB"; ValueData:"{app}\proj"; Flags: preservestringtype uninsdeletevalue
 
 Root: HKCR; Subkey: ".gda"; ValueType: string; ValueName: ""; ValueData: "GeoDaProjectFile"; Flags: uninsdeletevalue
 Root: HKCR; Subkey: "GeoDaProjectFile"; ValueType: string; ValueName: ""; ValueData: "GeoDa Project File"; Flags: uninsdeletekey

--- a/BuildTools/windows/installer/64bit/GeoDa.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa.iss
@@ -1,9 +1,9 @@
 [Setup]
 AppName=GeoDa                                                      
 AppPublisher=GeoDa Center
-AppPublisherURL=https://spatial.uchiago.edu/
-AppSupportURL=https://spatial.uchiago.edu/
-AppUpdatesURL=https://spatial.uchiago.edu/
+AppPublisherURL=https://spatial.uchicago.edu/
+AppSupportURL=https://spatial.uchicago.edu/
+AppUpdatesURL=https://spatial.uchicago.edu/
 AppSupportPhone=(480)965-7533
 AppVersion=1.20
 DefaultDirName={pf}\GeoDa Software


### PR DESCRIPTION
Remove dll registry from windows installers, since there is already runtime setup of GDAL dlls in the code.

Ref: 
https://github.com/GeoDaCenter/geoda/issues/2374
https://github.com/GeoDaCenter/geoda/issues/2375
