### PR TITLE
Fix: date field in table property editor crash windows

### DIFF
--- a/DataViewer/DataViewerEditFieldPropertiesDlg.cpp
+++ b/DataViewer/DataViewerEditFieldPropertiesDlg.cpp
@@ -196,8 +196,7 @@ void DataViewerEditFieldPropertiesDlg::InitTable()
 			field_grid->SetCellTextColour(r, COL_T, GdaConst::table_no_edit_color);
             
 			//field_grid->SetReadOnly(r, COL_T, true);
-            wxString strChoices[6] = {"real", "integer", "string", "date", "time", "datetime"};
-            field_grid->SetCellEditor(r, COL_T, new wxGridCellChoiceEditor(6, strChoices, false));
+            field_grid->SetCellEditor(r, COL_T, new wxGridCellChoiceEditor(6, FIELD_TYPE_CHOICES, false));
             
 			if (type == GdaConst::double_type) {
 				field_grid->SetCellValue(r, COL_T, "real");
@@ -411,10 +410,8 @@ void DataViewerEditFieldPropertiesDlg::OnCellChanging( wxGridEvent& ev )
 	int max_v;
     if (col == COL_T) {
         if (combo_selection >=0) {
-            wxString strChoices[6] = {"real", "integer", "string", "date",
-                "time", "datetime"};
             // change field type
-            wxString new_type_str = strChoices[combo_selection];
+            wxString new_type_str = FIELD_TYPE_CHOICES[combo_selection];
             if (new_type_str != type_str) {
                 GdaConst::FieldType new_type = GdaConst::unknown_type;
                 if (new_type_str == "real") {
@@ -735,8 +732,7 @@ void DataViewerEditFieldPropertiesDlg::OnCellEditorHidden( wxGridEvent& ev )
     
     if (col == 1) {
         if (combo_selection >=0) {
-            wxString strChoices[4] = {"real", "integer", "date","string"};
-            field_grid->SetCellValue(row, col, strChoices[combo_selection]);
+            field_grid->SetCellValue(row, col, FIELD_TYPE_CHOICES[combo_selection]);
         }
         combo_selection = -1;
     }

--- a/DataViewer/DataViewerEditFieldPropertiesDlg.h
+++ b/DataViewer/DataViewerEditFieldPropertiesDlg.h
@@ -92,6 +92,8 @@ private:
 	int COL_MAX; // max value possible
 	int NUM_COLS;
 	
+	const wxString FIELD_TYPE_CHOICES[6] = { "real", "integer", "string", "date", "time", "datetime" };
+
 	DECLARE_EVENT_TABLE()
 };
 

--- a/version.h
+++ b/version.h
@@ -2,9 +2,9 @@ namespace Gda {
     const int version_major = 1;
     const int version_minor = 20;
     const int version_build = 0;
-    const int version_subbuild = 20;
+    const int version_subbuild = 22;
     const int version_year = 2022;
-    const int version_month = 7;
+    const int version_month = 10;
     const int version_day = 15;
     const int version_night = 0;
     const int version_type = 2; // 0: alpha, 1: beta, 2: release


### PR DESCRIPTION
Convert a string field to datetime field using customized datetime format in table property editor crash windows