### PR TITLE
Enhancement: add datetime format (#2433)

### DIFF
--- a/DialogTools/PreferenceDlg.cpp
+++ b/DialogTools/PreferenceDlg.cpp
@@ -64,6 +64,18 @@
 using namespace std;
 using namespace GdaJson;
 
+const wxString DEFAULT_DATETIME_FORMATS = "%Y-%m-%d %H:%M:%S,"
+    "%Y/%m/%d %H:%M:%S,"
+    "%d.%m.%Y %H:%M:%S,"
+    "%m/%d/%Y %H:%M:%S,"
+    "%Y-%m-%d,"
+    "%m/%d/%Y,"
+    "%Y/%m/%d,"
+    "%H:%M:%S,"
+    "%H:%M,"
+    "%Y/%m/%d %H:%M %p,"
+    "%m/%d/%Y %I:%M:%S %p";
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // PreferenceDlg
@@ -509,7 +521,7 @@ void PreferenceDlg::OnReset(wxCommandEvent& ev)
     GdaConst::gda_user_seed = 123456789;
     GdaConst::default_display_decimals = 6;
     GdaConst::gda_autoweight_stop = 0.0001;
-    GdaConst::gda_datetime_formats_str = "%Y-%m-%d %H:%M:%S,%Y/%m/%d %H:%M:%S,%d.%m.%Y %H:%M:%S,%m/%d/%Y %H:%M:%S,%Y-%m-%d,%m/%d/%Y,%Y/%m/%d,%H:%M:%S,%H:%M,%Y/%m/%d %H:%M %p";
+    GdaConst::gda_datetime_formats_str = DEFAULT_DATETIME_FORMATS;
     GdaConst::gda_enable_set_transparency_windows = false;
     if (!GdaConst::gda_datetime_formats_str.empty()) {
         wxString patterns = GdaConst::gda_datetime_formats_str;
@@ -542,7 +554,7 @@ void PreferenceDlg::OnReset(wxCommandEvent& ev)
 	ogr_adapt.AddEntry("gdal_http_timeout", "5");
 	ogr_adapt.AddEntry("use_gda_user_seed", "1");
 	ogr_adapt.AddEntry("gda_user_seed", "123456789");
-	ogr_adapt.AddEntry("gda_datetime_formats_str", "%Y-%m-%d %H:%M:%S,%Y/%m/%d %H:%M:%S,%d.%m.%Y %H:%M:%S,%m/%d/%Y %H:%M:%S,%Y-%m-%d,%m/%d/%Y,%Y/%m/%d,%H:%M:%S,%H:%M,%Y/%m/%d %H:%M %p");
+	ogr_adapt.AddEntry("gda_datetime_formats_str", DEFAULT_DATETIME_FORMATS);
 	ogr_adapt.AddEntry("gda_cpu_cores", "6");
 	ogr_adapt.AddEntry("gda_set_cpu_cores", "1");
 	ogr_adapt.AddEntry("gda_eigen_tol", "1.0E-8");

--- a/GdaConst.cpp
+++ b/GdaConst.cpp
@@ -21,6 +21,7 @@
 #include "GeneralWxUtils.h"
 #include "GenUtils.h"
 #include <wx/mstream.h>
+#include <wx/tokenzr.h>
 
 // 10 local + 29 http
 const char* GdaConst::sample_names[] = {
@@ -359,8 +360,18 @@ int GdaConst::gda_ogr_csv_header = 1;
 wxString GdaConst::gda_ogr_csv_x_name = "";
 wxString GdaConst::gda_ogr_csv_y_name = "";
 wxString GdaConst::gda_display_datetime_format = "";
-std::vector<wxString> GdaConst::gda_datetime_formats(10);
-wxString GdaConst::gda_datetime_formats_str =  "%Y-%m-%d %H:%M:%S,%Y/%m/%d %H:%M:%S,%d.%m.%Y %H:%M:%S,%m/%d/%Y %H:%M:%S,%Y-%m-%d,%m/%d/%Y,%Y/%m/%d,%H:%M:%S,%H:%M,%Y/%m/%d %H:%M %p";
+std::vector<wxString> GdaConst::gda_datetime_formats;
+wxString GdaConst::gda_datetime_formats_str = "%Y-%m-%d %H:%M:%S,"
+    "%Y/%m/%d %H:%M:%S,"
+    "%d.%m.%Y %H:%M:%S,"
+    "%m/%d/%Y %H:%M:%S,"
+    "%Y-%m-%d,"
+    "%m/%d/%Y,"
+    "%Y/%m/%d,"
+    "%H:%M:%S,"
+    "%H:%M,"
+    "%Y/%m/%d %H:%M %p,"
+    "%m/%d/%Y %I:%M:%S %p";
 wxString GdaConst::gda_basemap_sources =
 "Carto.Light,https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png"
 "\nCarto.Dark,https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png"
@@ -585,16 +596,13 @@ void GdaConst::init()
                              wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
                              wxEmptyString, wxFONTENCODING_DEFAULT);
 
-    GdaConst::gda_datetime_formats[0] = "%Y-%m-%d %H:%M:%S";
-    GdaConst::gda_datetime_formats[1] = "%Y/%m/%d %H:%M:%S";
-    GdaConst::gda_datetime_formats[2] = "%d.%m.%Y %H:%M:%S";
-    GdaConst::gda_datetime_formats[3] = "%m/%d/%Y %H:%M:%S";
-    GdaConst::gda_datetime_formats[4] = "%Y-%m-%d";
-    GdaConst::gda_datetime_formats[5] = "%m/%d/%Y";
-    GdaConst::gda_datetime_formats[6] = "%Y/%m/%d";
-    GdaConst::gda_datetime_formats[7] = "%H:%M:%S";
-    GdaConst::gda_datetime_formats[8] = "%H:%M";
-    GdaConst::gda_datetime_formats[9] = "%Y/%m/%d %H:%M %p";
+    wxStringTokenizer tokenizer(GdaConst::gda_datetime_formats_str, ",");
+    while (tokenizer.HasMoreTokens())
+    {
+        wxString token = tokenizer.GetNextToken();
+        // process token here
+        GdaConst::gda_datetime_formats.push_back(token);
+    }
     
 	// GdaShape resources
 	default_myshape_pen = wxBLACK_PEN;

--- a/version.h
+++ b/version.h
@@ -2,10 +2,10 @@ namespace Gda {
     const int version_major = 1;
     const int version_minor = 20;
     const int version_build = 0;
-    const int version_subbuild = 38;
+    const int version_subbuild = 40;
     const int version_year = 2023;
-    const int version_month = 5;
-    const int version_day = 14;
+    const int version_month = 6;
+    const int version_day = 6;
     const int version_night = 0;
     const int version_type = 2; // 0: alpha, 1: beta, 2: release
 } // namespace Gda


### PR DESCRIPTION

Add "%m/%d/%Y %I:%M:%S %p" in the Preferences dialog to recognize datetime like “12/11/2020 11:45:00 PM”