### PR TITLE
Fix: fix incorrect type conversion in samples.sqlite

### DIFF
--- a/.github/workflows/osx_build.yml
+++ b/.github/workflows/osx_build.yml
@@ -9,7 +9,7 @@ on:
     branches: [master]
     paths-ignore:
       - '**/README.md'
-  pull_request:
+  pull_request_target:
     branches: [master]
     paths-ignore:
       - '**/README.md'

--- a/.github/workflows/osx_build.yml
+++ b/.github/workflows/osx_build.yml
@@ -2,11 +2,15 @@
 
 name: Mac OSX builds
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [master]
+    paths-ignore:
+      - '**/README.md'
+  pull_request:
+    branches: [master]
     paths-ignore:
       - '**/README.md'
 
@@ -25,14 +29,14 @@ jobs:
       GEODA_VER: '1.20.0'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
-    
+
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
       - name: Install application certificate
         uses: apple-actions/import-codesign-certs@v1
-        with: 
+        with:
           keychain: ${{ github.run_id }}
           keychain-password: ${{ github.run_id }}
           p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
@@ -50,14 +54,9 @@ jobs:
           security find-identity -v
           echo "start installing..."
           ./install.sh
-      
+
       # Upload artifact
       - uses: actions/upload-artifact@v2
         with:
           name: GeoDa-${{ env.GEODA_VER }}-MacOS
           path: ${{ github.workspace }}/BuildTools/macosx/create-dmg/GeoDa${{ env.GEODA_VER }}-Installer.dmg
-
-
-
-
-


### PR DESCRIPTION
This pr is a fix for #2435 

**Description**
Several of the original integer variables were turned into real. Details below:
- in Chicago community areas: the various identifier variables (area_num_1, areas_numbe, district no, geoid)
  are all real numbers, they were integer in the original
- same in carjackings: the integer variables became real
- in Chicago SDOH, the objectid is integer, but tractce10, geoid10, commarea turned into real
- in Ceara: code7 is real and should be integer, but state_code and micro_code are fine
- same problem for Oaxaca: id, mun, district and region should all be integer
- in Italy community banks: idd, id, idnn, regcode and provcode should be integer
- in spirals: cl should be integer

**Solution**
We use ogr2ogr to append a new shapefile to sample.sqlite, e.g.

```shell
ogr2ogr -update -append -f SQLite samples.sqlite -nln "Chicago Community Areas" -a_srs "EPSG:4326" Chicago_2020.shp
```

Note: the dbf file format has a number of limitations (see [here](https://gdal.org/drivers/vector/shapefile.html)):
- Integer fields without an explicit width are treated as width 9, and extended to 10 or 11 if needed.
- Integer64 fields without an explicit width are treated as width 18, and extended to 19 or 20 if needed.

By default, the GDAL library will read the dbf and select the larger data type. For example, a numeric column with width 19/20 may hold as Real. So, it is possible an Integer64 column with width 20 could be read as Real. 

There is one option `ADJUST_TYPE=YES/NO` that can be used to adjust Real->Integer/Integer64 or Integer64->Integer field types when possible. (see [Open options](https://gdal.org/drivers/vector/shapefile.html#open-options))

Therefore, to fix this issue, we need to add `-oo ADJUST_TYPE=YES` in the above ogr2ogr command.