### PR TITLE
Fix: use original CRS from datasources (#2441)

### DIFF
--- a/version.h
+++ b/version.h
@@ -1,11 +1,11 @@
 namespace Gda {
     const int version_major = 1;
-    const int version_minor = 20;
+    const int version_minor = 22;
     const int version_build = 0;
-    const int version_subbuild = 50;
+    const int version_subbuild = 0;
     const int version_year = 2023;
-    const int version_month = 6;
-    const int version_day = 26;
+    const int version_month = 7;
+    const int version_day = 12;
     const int version_night = 0;
     const int version_type = 2; // 0: alpha, 1: beta, 2: release
 } // namespace Gda


### PR DESCRIPTION
Below are the correct CRS for each of the data sets:

- Chicago community areas: lat-lon - OK

- Chicago Carjackings: is lat-lon, but should be
  +proj=tmerc +lat_0=36.6666666666667 +lon_0=-88.3333333333333 +k=0.999975 +x_0=300000 +y_0=0 +datum=NAD83 +units=us-ft +no_defs

- Chicago SDOH: is lat-lon, but should be
  +proj=tmerc +lat_0=36.6666666666667 +lon_0=-88.3333333333333 +k=0.999975 +x_0=300000 +y_0=0 +datum=NAD83 +units=us-ft +no_defs

- Ceara Zika: is lat-lon, but should be
  +proj=merc +lat_ts=-2 +lon_0=-43 +x_0=5000000 +y_0=10000000 +ellps=GRS80 +units=m +no_defs

- Oaxaca Development: is lat-lon - OK

- Italy Community Banks: is lat-lon, but should be
  +proj=utm +zone=32 +ellps=intl +units=m +no_defs
