### PR TITLE
Fix: use meter instead of metre (#2442)

### DIFF
--- a/GdaConst.cpp
+++ b/GdaConst.cpp
@@ -424,6 +424,9 @@ const wxString GdaConst::gda_lbl_n1sigma = "[-1Std, Mean)";
 const wxString GdaConst::gda_lbl_1sigma = "(Mean, 1Std]";
 const wxString GdaConst::gda_lbl_1sigma_2sigma = "(1Std, 2Std]";
 const wxString GdaConst::gda_lbl_2sigma = "> 2Std";
+const wxString GdaConst::gda_projection_UNIT = "UNIT";
+const wxString GdaConst::gda_projection_metre = "metre";
+const wxString GdaConst::gda_projection_meter = "meter";
 
 const wxPen* GdaConst::default_myshape_pen=0;
 const wxBrush* GdaConst::default_myshape_brush=0;

--- a/GdaConst.h
+++ b/GdaConst.h
@@ -240,6 +240,11 @@ public:
     static const wxString gda_lbl_1sigma_2sigma;
     static const wxString gda_lbl_2sigma;
     
+    // Projection
+    static const wxString gda_projection_UNIT;
+    static const wxString gda_projection_metre;
+    static const wxString gda_projection_meter;
+    
     // Languages
     static const wxString gda_lang_english;
     static const wxString gda_lang_chinese;

--- a/Project.cpp
+++ b/Project.cpp
@@ -1518,7 +1518,10 @@ bool Project::CommonProjectInit()
     // convert projection to WGS84 by default if there is projection
     sourceSR = GetSpatialReference();
     if (sourceSR ) {
-        project_unit = sourceSR->GetAttrValue("UNIT");
+        project_unit = sourceSR->GetAttrValue(GdaConst::gda_projection_UNIT);
+        if (project_unit.CmpNoCase(GdaConst::gda_projection_metre) == 0) {
+            project_unit = GdaConst::gda_projection_meter;
+        }
     }
     // configurations for save gda project file
     LayerConfiguration* layer_conf = project_conf->GetLayerConfiguration();


### PR DESCRIPTION
Distance unit in Weights manager is given as "metre" but should be "meter"