### PR TITLE
Test: update control dependencies in Jammy

### DIFF
--- a/BuildTools/ubuntu/package/DEBIAN/control_jammy
+++ b/BuildTools/ubuntu/package/DEBIAN/control_jammy
@@ -4,7 +4,7 @@ Architecture: amd64
 Priority: optional
 Section: graphics
 Installed-Size: 121795
-Depends: libgdal33, zlib1g, libexpat1, freeglut3, libreadline8, libgtk-3-0, libssl3, libwebkit2gtk-4.1-0
+Depends: libgdal33, zlib1g, libexpat1, libglut3.12, libreadline8, libgtk-3-0, libssl3, libwebkit2gtk-4.1-0
 Maintainer: Luc Anselin < anselin@uchicago.edu >
 Provides: geoda
 Homepage: http://spatial.uchicago.edu

--- a/BuildTools/ubuntu/package/DEBIAN/control_jammy
+++ b/BuildTools/ubuntu/package/DEBIAN/control_jammy
@@ -4,7 +4,7 @@ Architecture: amd64
 Priority: optional
 Section: graphics
 Installed-Size: 121795
-Depends: libgdal30, zlib1g, libexpat1, freeglut3, libreadline8, libgtk-3-0, libssl3, libwebkit2gtk-4.0-37
+Depends: libgdal33, zlib1g, libexpat1, freeglut3, libreadline8, libgtk-3-0, libssl3, libwebkit2gtk-4.1-0
 Maintainer: Luc Anselin < anselin@uchicago.edu >
 Provides: geoda
 Homepage: http://spatial.uchicago.edu


### PR DESCRIPTION
I've tried to install the GeoDa package on a clean Ubuntu 22.04 Jammy. The original control file works fine:
```
Depends: libgdal33, zlib1g, libexpat1, freeglut3, libreadline8, libgtk-3-0, libssl3, libwebkit2gtk-4.1-0
```

This PR is for issue https://github.com/GeoDaCenter/geoda/issues/2464.