### PR TITLE
[Fix] reprojection not working when adding basemap layer

### DIFF
--- a/.github/workflows/osx_build.yml
+++ b/.github/workflows/osx_build.yml
@@ -70,6 +70,7 @@ jobs:
           arch
           brew install gdal
           sudo ln -s /opt/homebrew/opt/gdal /usr/local/opt/gdal
+          sudo ln -s /opt/homebrew/opt/proj /usr/local/opt/proj
 
       - uses: actions/cache@v3
         id: cache

--- a/.github/workflows/osx_build.yml
+++ b/.github/workflows/osx_build.yml
@@ -71,7 +71,6 @@ jobs:
           brew install gdal
           sudo ln -s /opt/homebrew/opt/gdal /usr/local/opt/gdal
           sudo ln -s /opt/homebrew/opt/proj /usr/local/opt/proj
-          ls -lrt /usr/local/opt/proj/share/proj
 
       - uses: actions/cache@v3
         id: cache

--- a/BuildTools/CommonDistFiles/osx/proj/CH
+++ b/BuildTools/CommonDistFiles/osx/proj/CH
@@ -3,8 +3,7 @@
 # See: https://shop.swisstopo.admin.ch/en/products/geo_software/GIS_info
 #
 # You'll need to download the grids separately and put in a directory
-# scanned by libproj. Directories may be added to the scan list through
-# the PROJ_LIB environment variable
+# scanned by libproj.
 #
 # Note that an independent effort was made to derive an usable grid
 # from the CH1903->CH1903+ grid initially available from the Swisstopo

--- a/BuildTools/CommonDistFiles/osx/proj/ITRF2008
+++ b/BuildTools/CommonDistFiles/osx/proj/ITRF2008
@@ -42,20 +42,53 @@
 
 <CARB> +proj=helmert +drx=0.000049 +dry=-0.001088 +drz=0.000664 +convention=position_vector
 
-<EURA> +proj=helmert +drx=-0.000083 +dry=0.000534 +drz=0.000750 +convention=position_vector
+<EURA> +proj=helmert +drx=-0.000083 +dry=-0.000534 +drz=0.000750 +convention=position_vector
 
 <INDI> +proj=helmert +drx=0.001232 +dry=0.000303 +drz=0.001540 +convention=position_vector
 
 <NAZC> +proj=helmert +drx=-0.000330 +dry=-0.001551 +drz=0.001625 +convention=position_vector
 
-<NOAM> +proj=helmert +drx=0.000035 +dry=-0.000662 +drz=0.0001 +convention=position_vector
+<NOAM> +proj=helmert +drx=0.000035 +dry=-0.000662 +drz=-0.0001 +convention=position_vector
 
 <NUBI> +proj=helmert +drx=0.000095 +dry=-0.000598 +drz=0.000723 +convention=position_vector
 
-<PCFC> +proj=helmert +drx=0.000411 +dry=0.001036 +drz=-0.002166 +convention=position_vector
+<PCFC> +proj=helmert +drx=-0.000411 +dry=0.001036 +drz=-0.002166 +convention=position_vector
 
 <SOAM> +proj=helmert +drx=-0.000243 +dry=-0.000311 +drz=-0.000154 +convention=position_vector
 
 <SOMA> +proj=helmert +drx=-0.000080 +dry=-0.000745 +drz=0.000897 +convention=position_vector
 
 <SUND> +proj=helmert +drx=0.000047 +dry=-0.001 +drz=0.000975 +convention=position_vector
+
+
+# Plate names suffixed by _T (for Translation) that includes the translation
+# rates +dx=0.00041 +dy=0.00022 +dz=0.00041 given by Table 2 of the ITRF2008 plate motion model
+# paper
+
+<AMUR_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=-0.000190 +dry=-0.000442 +drz=0.000915 +convention=position_vector
+
+<ANTA_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=-0.000252 +dry=-0.000302 +drz=0.000643 +convention=position_vector
+
+<ARAB_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=0.001202 +dry=-0.000054 +drz=0.001485 +convention=position_vector
+
+<AUST_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=0.001504 +dry=0.001172 +drz=0.001228 +convention=position_vector
+
+<CARB_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=0.000049 +dry=-0.001088 +drz=0.000664 +convention=position_vector
+
+<EURA_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=-0.000083 +dry=-0.000534 +drz=0.000750 +convention=position_vector
+
+<INDI_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=0.001232 +dry=0.000303 +drz=0.001540 +convention=position_vector
+
+<NAZC_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=-0.000330 +dry=-0.001551 +drz=0.001625 +convention=position_vector
+
+<NOAM_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=0.000035 +dry=-0.000662 +drz=-0.0001 +convention=position_vector
+
+<NUBI_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=0.000095 +dry=-0.000598 +drz=0.000723 +convention=position_vector
+
+<PCFC_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=-0.000411 +dry=0.001036 +drz=-0.002166 +convention=position_vector
+
+<SOAM_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=-0.000243 +dry=-0.000311 +drz=-0.000154 +convention=position_vector
+
+<SOMA_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=-0.000080 +dry=-0.000745 +drz=0.000897 +convention=position_vector
+
+<SUND_T> +proj=helmert +dx=0.00041 +dy=0.00022 +dz=0.00041 +drx=0.000047 +dry=-0.001 +drz=0.000975 +convention=position_vector

--- a/BuildTools/CommonDistFiles/osx/proj/ITRF2014
+++ b/BuildTools/CommonDistFiles/osx/proj/ITRF2014
@@ -9,9 +9,9 @@
 
 <ITRF97> +proj=helmert +x=0.0074 +y=-0.0005 +z=-0.0628 +d=0.0038 +rz=0.00026 +dx0.0001	+dy=-0.0005 +dz=-0.0033	+ds=0.00012 +drz=0.00002 +t_epoch=2010.0 +convention=position_vector
 
-<ITRF96> +proj=helmert +x=0.0074 +y=-0.0005 +z=-0.0628 +s=0.0038 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +t_epoch=2010.0 +convention=position_vector
+<ITRF96> +proj=helmert +x=0.0074 +y=-0.0005 +z=-0.0628 +s=0.0038 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +t_epoch=2010.0 +convention=position_vector
 
-<ITRF94> +proj=helmert +x=0.0074 +y=-0.0005 +z=-0.0628 +s=0.0038 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +t_epoch=2010.0 +convention=position_vector
+<ITRF94> +proj=helmert +x=0.0074 +y=-0.0005 +z=-0.0628 +s=0.0038 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +t_epoch=2010.0 +convention=position_vector
 
 <ITRF93> +proj=helmert +x=-0.0504 +y=0.0033 +z=-0.0602 +s=0.00429 +rx=-0.00281 +ry=-0.00338 +rz=0.0004 +dx=-0.0028 +dy=-0.0001 +dz=-0.0025 +ds=0.00012 +drx=-0.00011 +dry=-0.00019 +drz=0.00007 +t_epoch=2010.0 +convention=position_vector
 
@@ -23,7 +23,7 @@
 
 <ITRF89> +proj=helmert +x=0.0304 +y=0.0355 +z=-0.1308 +s=0.00819 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +t_epoch=2010.0 +convention=position_vector
 
-<ITRF88> +proj=helmert +x=0.0254 +y=-0.0005 +z=-0.1548 +s=0.01129 +rx=0.0001 +rz= +dx=0.00026 +dy=0.0001 +dx=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +t_epoch=2010.0 +convention=position_vector
+<ITRF88> +proj=helmert +x=0.0254 +y=-0.0005 +z=-0.1548 +s=0.01129 +rx=0.0001 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +t_epoch=2010.0 +convention=position_vector
 
 # ITRF2014 Plate Motion Model parameters
 #

--- a/BuildTools/CommonDistFiles/osx/proj/proj.ini
+++ b/BuildTools/CommonDistFiles/osx/proj/proj.ini
@@ -4,16 +4,43 @@
 
 ; Network capabilities disabled by default.
 ; Can be overridden with the PROJ_NETWORK=ON environment variable.
-; network = on
+; Cf https://proj.org/en/latest/usage/network.html
+; Valid values = on, off
+network = off
 
+; Endpoint of the Content Delivery Network where remote resources might
+; be accessed. Only used if network access is allowed (cf above "network"
+; option)
 ; Can be overridden with the PROJ_NETWORK_ENDPOINT environment variable.
 cdn_endpoint = https://cdn.proj.org
 
+; Whether to enable a cache of remote resources that are accessed, on the
+; local file system
+; Valid values = on, off
 cache_enabled = on
 
+; Size of the cache in megabytes
 cache_size_MB = 300
 
+; Time-to-live delay in seconds before already accessed remote resources are
+; acessed again to check if they have been updated.
 cache_ttl_sec = 86400
+
+; Can be set to on so that by default the lack of a known resource files needed
+; for the best transformation PROJ would normally use causes an error, or off
+; to accept missing resource files without errors or warnings.
+; This default value itself is overriden by the PROJ_ONLY_BEST_DEFAULT environment
+; variable if set, and then by the ONLY_BEST setting that can be
+; passed to the proj_create_crs_to_crs() method, or with the --only-best
+; option of the cs2cs program.
+; (added in PROJ 9.2)
+; Valid values = on, off
+only_best_default = off
+
+; Filename of the Certificate Authority (CA) bundle.
+; Can be overriden with the PROJ_CURL_CA_BUNDLE / CURL_CA_BUNDLE environment variable.
+; (added in PROJ 9.0)
+; ca_bundle_path = /path/to/cabundle.pem
 
 ; Transverse Mercator (and UTM)  default algorithm: auto, evenden_snyder or poder_engsager
 ; * evenden_snyder is the fastest, but less accurate far from central meridian

--- a/BuildTools/CommonDistFiles/osx/proj/projjson.schema.json
+++ b/BuildTools/CommonDistFiles/osx/proj/projjson.schema.json
@@ -1,8 +1,8 @@
 {
-  "$id": "https://proj.org/schemas/v0.4/projjson.schema.json",
+  "$id": "https://proj.org/schemas/v0.7/projjson.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Schema for PROJJSON (v0.4)",
-  "$comment": "This file exists both in data/ and in schemas/vXXX/. Keep both in sync. And if changing the value of $id, change PROJJSON_CURRENT_VERSION accordingly in io.cpp",
+  "description": "Schema for PROJJSON (v0.7)",
+  "$comment": "This file exists both in data/ and in schemas/vXXX/. Keep both in sync. And if changing the value of $id, change PROJJSON_DEFAULT_VERSION accordingly in io.cpp",
 
   "oneOf": [
     { "$ref": "#/definitions/crs" },
@@ -11,7 +11,8 @@
     { "$ref": "#/definitions/ellipsoid" },
     { "$ref": "#/definitions/prime_meridian" },
     { "$ref": "#/definitions/single_operation" },
-    { "$ref": "#/definitions/concatenated_operation" }
+    { "$ref": "#/definitions/concatenated_operation" },
+    { "$ref": "#/definitions/coordinate_metadata" }
   ],
 
   "definitions": {
@@ -22,6 +23,10 @@
         "$schema" : { "type": "string" },
         "type": { "type": "string", "enum": ["AbridgedTransformation"] },
         "name": { "type": "string" },
+        "source_crs": {
+            "$ref": "#/definitions/crs",
+            "$comment": "Only present when the source_crs of the bound_crs does not match the source_crs of the AbridgedTransformation. No equivalent in WKT"
+        },
         "method": { "$ref": "#/definitions/method" },
         "parameters": {
             "type": "array",
@@ -85,7 +90,11 @@
                                  "future",
                                  "past",
                                  "unspecified" ] },
+        "meridian": { "$ref": "#/definitions/meridian" },
         "unit": { "$ref": "#/definitions/unit" },
+        "minimum_value": { "type": "number" },
+        "maximum_value": { "type": "number" },
+        "range_meaning": { "type": "string", "enum": [ "exact", "wraparound"] },
         "id": { "$ref": "#/definitions/id" },
         "ids": { "$ref": "#/definitions/ids" }
       },
@@ -122,6 +131,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -144,6 +155,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -164,10 +177,13 @@
            "type": "array",
             "items": { "$ref": "#/definitions/single_operation" }
         },
+        "accuracy": { "type": "string" },
         "$schema" : {},
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -197,6 +213,18 @@
       "additionalProperties": false
     },
 
+    "coordinate_metadata": {
+      "type": "object",
+      "properties": {
+        "$schema" : { "type": "string" },
+        "type": { "type": "string", "enum": ["CoordinateMetadata"] },
+        "crs": { "$ref": "#/definitions/crs" },
+        "coordinateEpoch": { "type": "number" }
+      },
+      "required" : [ "crs" ],
+      "additionalProperties": false
+    },
+
     "coordinate_system": {
       "type": "object",
       "properties": {
@@ -210,6 +238,7 @@
                               "vertical",
                               "ordinal",
                               "parametric",
+                              "affine",
                               "TemporalDateTime",
                               "TemporalCount",
                               "TemporalMeasure"]  },
@@ -292,6 +321,17 @@
       "additionalProperties": false
     },
 
+    "deformation_model": {
+      "description": "Association to a PointMotionOperation",
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "id": { "$ref": "#/definitions/id" }
+      },
+      "required" : [ "name" ],
+      "additionalProperties": false
+    },
+
     "derived_engineering_crs": {
       "type": "object",
       "allOf": [{ "$ref": "#/definitions/object_usage" }],
@@ -306,6 +346,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -329,6 +371,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -351,6 +395,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -373,6 +419,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -395,6 +443,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -417,6 +467,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -427,19 +479,21 @@
 
     "dynamic_geodetic_reference_frame": {
       "type": "object",
-      "allOf": [{ "$ref": "#/definitions/geodetic_reference_frame" }],
+      "allOf": [{ "$ref": "#/definitions/object_usage" }],
       "properties": {
         "type": { "type": "string", "enum": ["DynamicGeodeticReferenceFrame"] },
         "name": {},
         "anchor": {},
+        "anchor_epoch": {},
         "ellipsoid": {},
         "prime_meridian": {},
         "frame_reference_epoch": { "type": "number" },
-        "deformation_model": { "type": "string" },
         "$schema" : {},
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -450,17 +504,19 @@
 
     "dynamic_vertical_reference_frame": {
       "type": "object",
-      "allOf": [{ "$ref": "#/definitions/vertical_reference_frame" }],
+      "allOf": [{ "$ref": "#/definitions/object_usage" }],
       "properties": {
         "type": { "type": "string", "enum": ["DynamicVerticalReferenceFrame"] },
         "name": {},
         "anchor": {},
+        "anchor_epoch": {},
         "frame_reference_epoch": { "type": "number" },
-        "deformation_model": { "type": "string" },
         "$schema" : {},
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -528,6 +584,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -547,6 +605,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -568,10 +628,16 @@
         },
         "datum_ensemble": { "$ref": "#/definitions/datum_ensemble" },
         "coordinate_system": { "$ref": "#/definitions/coordinate_system" },
+        "deformation_models": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/deformation_model" }
+        },
         "$schema" : {},
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -592,17 +658,31 @@
         "type": { "type": "string", "enum": ["GeodeticReferenceFrame"] },
         "name": { "type": "string" },
         "anchor": { "type": "string" },
+        "anchor_epoch": { "type": "number" },
         "ellipsoid": { "$ref": "#/definitions/ellipsoid" },
         "prime_meridian": { "$ref": "#/definitions/prime_meridian" },
         "$schema" : {},
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
       },
       "required" : [ "name", "ellipsoid" ],
+      "additionalProperties": false
+    },
+
+    "geoid_model": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "interpolation_crs": { "$ref": "#/definitions/crs" },
+        "id": { "$ref": "#/definitions/id" }
+      },
+      "required" : [ "name" ],
       "additionalProperties": false
     },
 
@@ -668,6 +748,22 @@
       ]
     },
 
+    "meridian": {
+      "type": "object",
+      "properties": {
+        "$schema" : { "type": "string" },
+        "type": { "type": "string", "enum": ["Meridian"] },
+        "longitude": { "$ref": "#/definitions/value_in_degree_or_value_and_unit" },
+        "id": { "$ref": "#/definitions/id" },
+        "ids": { "$ref": "#/definitions/ids" }
+      },
+      "required" : [ "longitude" ],
+      "allOf": [
+        { "$ref": "#/definitions/id_ids_mutually_exclusive" }
+      ],
+      "additionalProperties": false
+    },
+
     "object_usage": {
       "anyOf": [
       {
@@ -677,6 +773,8 @@
             "scope": { "type": "string" },
             "area": { "type": "string" },
             "bbox": { "$ref": "#/definitions/bbox" },
+            "vertical_extent": { "$ref": "#/definitions/vertical_extent" },
+            "temporal_extent": { "$ref": "#/definitions/temporal_extent" },
             "remarks": { "type": "string" },
             "id": { "$ref": "#/definitions/id" },
             "ids": { "$ref": "#/definitions/ids" }
@@ -736,6 +834,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -755,11 +855,41 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
       },
       "required" : [ "name" ],
+      "additionalProperties": false
+    },
+
+    "point_motion_operation": {
+      "$comment": "Not implemented in PROJ (at least as of PROJ 9.1)",
+      "type": "object",
+      "allOf": [{ "$ref": "#/definitions/object_usage" }],
+      "properties": {
+        "type": { "type": "string", "enum": ["PointMotionOperation"] },
+        "name": { "type": "string" },
+        "source_crs": { "$ref": "#/definitions/crs" },
+        "method": { "$ref": "#/definitions/method" },
+        "parameters": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/parameter_value" }
+        },
+        "accuracy": { "type": "string" },
+        "$schema" : {},
+        "scope": {},
+        "area": {},
+        "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
+        "usages": {},
+        "remarks": {},
+        "id": {}, "ids": {}
+      },
+      "required" : [ "name", "source_crs", "method", "parameters" ],
       "additionalProperties": false
     },
 
@@ -783,7 +913,8 @@
     "single_operation": {
       "oneOf": [
         { "$ref": "#/definitions/conversion" },
-        { "$ref": "#/definitions/transformation" }
+        { "$ref": "#/definitions/transformation" },
+        { "$ref": "#/definitions/point_motion_operation" }
       ]
     },
 
@@ -801,6 +932,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -821,6 +954,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -841,11 +976,23 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
       },
       "required" : [ "name", "calendar" ],
+      "additionalProperties": false
+    },
+
+    "temporal_extent": {
+      "type": "object",
+      "properties": {
+        "start": { "type": "string" },
+        "end": { "type": "string" }
+      },
+      "required" : [ "start", "end" ],
       "additionalProperties": false
     },
 
@@ -868,6 +1015,8 @@
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -909,7 +1058,9 @@
           "properties": {
             "scope": { "type": "string" },
             "area": { "type": "string" },
-            "bbox": { "$ref": "#/definitions/bbox" }
+            "bbox": { "$ref": "#/definitions/bbox" },
+            "vertical_extent": { "$ref": "#/definitions/vertical_extent" },
+            "temporal_extent": { "$ref": "#/definitions/temporal_extent" }
            },
           "additionalProperties": false
         }
@@ -952,20 +1103,21 @@
         },
         "datum_ensemble": { "$ref": "#/definitions/datum_ensemble" },
         "coordinate_system": { "$ref": "#/definitions/coordinate_system" },
-        "geoid_model": {
-          "type": "object",
-          "properties": {
-            "name": { "type": "string" },
-            "interpolation_crs": { "$ref": "#/definitions/crs" },
-            "id": { "$ref": "#/definitions/id" }
-          },
-          "required" : [ "name" ],
-          "additionalProperties": false
+        "geoid_model": { "$ref": "#/definitions/geoid_model" },
+        "geoid_models": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/geoid_model" }
+        },
+        "deformation_models": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/deformation_model" }
         },
         "$schema" : {},
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}
@@ -974,8 +1126,25 @@
       "description": "One and only one of datum and datum_ensemble must be provided",
       "allOf": [
         { "$ref": "#/definitions/object_usage" },
-        { "$ref": "#/definitions/one_and_only_one_of_datum_or_datum_ensemble" }
+        { "$ref": "#/definitions/one_and_only_one_of_datum_or_datum_ensemble" },
+        {
+            "not": {
+                "type": "object",
+                "required": [ "geoid_model", "geoid_models" ]
+            }
+        }
       ],
+      "additionalProperties": false
+    },
+
+    "vertical_extent": {
+      "type": "object",
+      "properties": {
+        "minimum": { "type": "number" },
+        "maximum": { "type": "number" },
+        "unit": { "$ref": "#/definitions/unit" }
+      },
+      "required" : [ "minimum", "maximum" ],
       "additionalProperties": false
     },
 
@@ -986,10 +1155,13 @@
         "type": { "type": "string", "enum": ["VerticalReferenceFrame"] },
         "name": { "type": "string" },
         "anchor": { "type": "string" },
+        "anchor_epoch": { "type": "number" },
         "$schema" : {},
         "scope": {},
         "area": {},
         "bbox": {},
+        "vertical_extent": {},
+        "temporal_extent": {},
         "usages": {},
         "remarks": {},
         "id": {}, "ids": {}

--- a/BuildTools/macosx/GNUmakefile
+++ b/BuildTools/macosx/GNUmakefile
@@ -107,7 +107,7 @@ build-geoda-mac:
 	cp /usr/local/opt/proj/share/proj/NKG build/GeoDa.app/Contents/Resources/proj
 	cp /usr/local/opt/proj/share/proj/other.extra build/GeoDa.app/Contents/Resources/proj
 	cp /usr/local/opt/proj/share/proj/proj.db build/GeoDa.app/Contents/Resources/proj
-	cp /usr/local/opt/proj/share/proj/proj.init build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/proj.ini build/GeoDa.app/Contents/Resources/proj
 	cp /usr/local/opt/proj/share/proj/projjson.schema.json build/GeoDa.app/Contents/Resources/proj
 	cp /usr/local/opt/proj/share/proj/deformation_model.schema.json build/GeoDa.app/Contents/Resources/proj
 	cp /usr/local/opt/proj/share/proj/triangulation.schema.json build/GeoDa.app/Contents/Resources/proj

--- a/BuildTools/macosx/GNUmakefile
+++ b/BuildTools/macosx/GNUmakefile
@@ -77,13 +77,13 @@ build-geoda-mac:
 	mkdir -p build/GeoDa.app/Contents/Frameworks
 	mkdir -p build/GeoDa.app/Contents/Resources
 	mkdir -p build/GeoDa.app/Contents/Resources/gdaldata
+	mkdir -p build/GeoDa.app/Contents/Resources/proj
 	mkdir -p build/GeoDa.app/Contents/Resources/plugins
 	mkdir -p build/GeoDa.app/Contents/Resources/basemap_cache
 	mkdir -p build/GeoDa.app/Contents/Resources/web_plugins
 	cp $(GeoDa_ROOT)/BuildTools/CommonDistFiles/web_plugins/*.* build/GeoDa.app/Contents/Resources/web_plugins
 	cp $(GeoDa_ROOT)/BuildTools/CommonDistFiles/cache.sqlite build/GeoDa.app/Contents/Resources
 	cp $(GeoDa_ROOT)/Algorithms/lisa_kernel.cl build/GeoDa.app/Contents/MacOS
-	cp -rf $(GeoDa_ROOT)/BuildTools/CommonDistFiles/osx/proj build/GeoDa.app/Contents/Resources
 	cp -rf $(GeoDa_ROOT)/internationalization/lang build/GeoDa.app/Contents/Resources
 	$(LD) $(LDFLAGS) $(GeoDa_OBJ) $(LIBS) -o build/GeoDa.app/Contents/MacOS/GeoDa
 	cp GeoDa-GDAL-Info.plist build/GeoDa.app/Contents/Info.plist
@@ -93,6 +93,25 @@ build-geoda-mac:
 	cp $(GeoDa_ROOT)/rc/menus.xrc build/GeoDa.app/Contents/Resources
 	cp $(GeoDa_ROOT)/rc/toolbar.xrc build/GeoDa.app/Contents/Resources
 	cp /usr/local/opt/gdal/share/gdal/* build/GeoDa.app/Contents/Resources/gdaldata
+	cp /usr/local/opt/proj/share/proj/CH build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/DK build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/FO build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/GL27 build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/ISL build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/ITRF2000 build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/ITRF2008 build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/ITRF2014 build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/nad.lst build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/nad27 build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/nad83 build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/NKG build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/other.extra build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/proj.db build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/proj.init build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/projjson.schema.json build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/deformation_model.schema.json build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/triangulation.schema.json build/GeoDa.app/Contents/Resources/proj
+	cp /usr/local/opt/proj/share/proj/world build/GeoDa.app/Contents/Resources/proj
 	cp libraries/lib/libwx_osx_cocoau-3.2.0.2.2.dylib build/GeoDa.app/Contents/Frameworks/libwx_osx_cocoau-3.2.dylib
 	cp libraries/lib/libwx_osx_cocoau_gl-3.2.0.2.2.dylib build/GeoDa.app/Contents/Frameworks/libwx_osx_cocoau_gl-3.2.dylib
 	cp /usr/local/opt/gdal/lib/libgdal.35.dylib build/GeoDa.app/Contents/Frameworks

--- a/version.h
+++ b/version.h
@@ -2,10 +2,10 @@ namespace Gda {
     const int version_major = 1;
     const int version_minor = 22;
     const int version_build = 0;
-    const int version_subbuild = 8;
+    const int version_subbuild = 10;
     const int version_year = 2024;
-    const int version_month = 8;
-    const int version_day = 14;
+    const int version_month = 10;
+    const int version_day = 8;
     const int version_night = 0;
     const int version_type = 2; // 0: alpha, 1: beta, 2: release
 } // namespace Gda


### PR DESCRIPTION
See description in https://github.com/GeoDaCenter/geoda/issues/2499

To avoid such an issue in the future, this PR tries to copy the proj resources from the brew installation `/usr/local/opt/proj/share/proj` to GeoDa whenever building a new installer for Mac.