### PR TITLE
Fix: allow silent uninstall previous GeoDa using Microsoft MECM 

### DIFF
--- a/BuildTools/windows/installer/32bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/32bit/GeoDa-win7+.iss
@@ -208,33 +208,57 @@ begin
   
   if IsGeoDaInstalled then
   begin
-    V := MsgBox('An existing version of GeoDa was detected. Would you like to automatically uninstall it before installing the new version?' + #13#10 + #13#10 + 
-                'Click Yes to automatically uninstall the existing version.' + #13#10 +
-                'Click No to cancel the installation.', mbInformation, MB_YESNO);
-    if V = IDYES then
+    // Check if installer is running in silent mode
+    if WizardSilent() then
     begin
+      // In silent mode, automatically uninstall existing version
       UninstallAttempted := True;
       if UninstallExistingGeoDa() then
       begin
         // Check if uninstall was successful
         if IsGeoDaInstalled then
         begin
-          V := MsgBox('The automatic uninstall may not have completed successfully. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
+          // In silent mode, continue anyway to avoid blocking
+          Log('Warning: Automatic uninstall may not have completed successfully, but continuing with installation in silent mode.');
+        end;
+      end
+      else
+      begin
+        // In silent mode, continue anyway to avoid blocking
+        Log('Warning: Failed to automatically uninstall existing version, but continuing with installation in silent mode.');
+      end;
+    end
+    else
+    begin
+      // Interactive mode - show message box
+      V := MsgBox('An existing version of GeoDa was detected. Would you like to automatically uninstall it before installing the new version?' + #13#10 + #13#10 + 
+                  'Click Yes to automatically uninstall the existing version.' + #13#10 +
+                  'Click No to cancel the installation.', mbInformation, MB_YESNO);
+      if V = IDYES then
+      begin
+        UninstallAttempted := True;
+        if UninstallExistingGeoDa() then
+        begin
+          // Check if uninstall was successful
+          if IsGeoDaInstalled then
+          begin
+            V := MsgBox('The automatic uninstall may not have completed successfully. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
+                        'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
+            if V = IDNO then
+              Result := False;
+          end;
+        end
+        else
+        begin
+          V := MsgBox('Failed to automatically uninstall the existing version. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
                       'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
           if V = IDNO then
             Result := False;
         end;
       end
       else
-      begin
-        V := MsgBox('Failed to automatically uninstall the existing version. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
-                    'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
-        if V = IDNO then
-          Result := False;
-      end;
-    end
-    else
-      Result := False; //when older version present and user chose not to uninstall
+        Result := False; //when older version present and user chose not to uninstall
+    end;
   end;
 end;
 

--- a/BuildTools/windows/installer/32bit/GeoDa.iss
+++ b/BuildTools/windows/installer/32bit/GeoDa.iss
@@ -156,21 +156,71 @@ begin
             RegValueExists(HKEY_CURRENT_USER,'Software\Microsoft\Windows\CurrentVersion\Uninstall\GeoDa_is2', 'UninstallString');
 end;
 
+function GetUninstallParameters: string;
+var
+  UninstallParams: string;
+  i: Integer;
+  HasSilentMode: Boolean;
+  HasSuppressMsgBox: Boolean;
+begin
+  UninstallParams := '';
+  HasSilentMode := False;
+  HasSuppressMsgBox := False;
+  
+  // Check all parameters for silent mode and suppress message box flags
+  for i := 1 to ParamCount do
+  begin
+    if ParamStr(i) = '/VERYSILENT' then
+    begin
+      UninstallParams := '/VERYSILENT';
+      HasSilentMode := True;
+    end
+    else if ParamStr(i) = '/SILENT' then
+    begin
+      if not HasSilentMode then
+      begin
+        UninstallParams := '/SILENT';
+        HasSilentMode := True;
+      end;
+    end
+    else if ParamStr(i) = '/SUPPRESSMSGBOXES' then
+    begin
+      HasSuppressMsgBox := True;
+    end;
+  end;
+  
+  // If no silent mode was found, default to /SILENT for interactive mode
+  if not HasSilentMode then
+  begin
+    UninstallParams := '/SILENT';
+  end;
+  
+  // Add /SUPPRESSMSGBOXES if it was found
+  if HasSuppressMsgBox then
+  begin
+    UninstallParams := UninstallParams + ' /SUPPRESSMSGBOXES';
+  end;
+  
+  Result := UninstallParams;
+end;
+
 function UninstallExistingGeoDa: Boolean;
 var
   iResultCode: Integer;
   sUnInstallString: string;
   UninstallSuccess: Boolean;
+  UninstallParams: string;
 begin
   Result := True;
   UninstallSuccess := False;
+  UninstallParams := GetUninstallParameters();
   
   // Try first uninstall string
   sUnInstallString := GetUninstallString();
   if sUnInstallString <> '' then
   begin
     sUnInstallString := RemoveQuotes(sUnInstallString);
-    if Exec(ExpandConstant(sUnInstallString), '/SILENT', '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
+    if Exec(ExpandConstant(sUnInstallString), UninstallParams, '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
     begin
       UninstallSuccess := True;
     end;
@@ -183,7 +233,7 @@ begin
     if sUnInstallString <> '' then
     begin
       sUnInstallString := RemoveQuotes(sUnInstallString);
-      if Exec(ExpandConstant(sUnInstallString), '/SILENT', '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
+      if Exec(ExpandConstant(sUnInstallString), UninstallParams, '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
       begin
         UninstallSuccess := True;
       end;

--- a/BuildTools/windows/installer/32bit/GeoDa.iss
+++ b/BuildTools/windows/installer/32bit/GeoDa.iss
@@ -207,33 +207,57 @@ begin
   
   if IsGeoDaInstalled then
   begin
-    V := MsgBox('An existing version of GeoDa was detected. Would you like to automatically uninstall it before installing the new version?' + #13#10 + #13#10 + 
-                'Click Yes to automatically uninstall the existing version.' + #13#10 +
-                'Click No to cancel the installation.', mbInformation, MB_YESNO);
-    if V = IDYES then
+    // Check if installer is running in silent mode
+    if WizardSilent() then
     begin
+      // In silent mode, automatically uninstall existing version
       UninstallAttempted := True;
       if UninstallExistingGeoDa() then
       begin
         // Check if uninstall was successful
         if IsGeoDaInstalled then
         begin
-          V := MsgBox('The automatic uninstall may not have completed successfully. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
+          // In silent mode, continue anyway to avoid blocking
+          Log('Warning: Automatic uninstall may not have completed successfully, but continuing with installation in silent mode.');
+        end;
+      end
+      else
+      begin
+        // In silent mode, continue anyway to avoid blocking
+        Log('Warning: Failed to automatically uninstall existing version, but continuing with installation in silent mode.');
+      end;
+    end
+    else
+    begin
+      // Interactive mode - show message box
+      V := MsgBox('An existing version of GeoDa was detected. Would you like to automatically uninstall it before installing the new version?' + #13#10 + #13#10 + 
+                  'Click Yes to automatically uninstall the existing version.' + #13#10 +
+                  'Click No to cancel the installation.', mbInformation, MB_YESNO);
+      if V = IDYES then
+      begin
+        UninstallAttempted := True;
+        if UninstallExistingGeoDa() then
+        begin
+          // Check if uninstall was successful
+          if IsGeoDaInstalled then
+          begin
+            V := MsgBox('The automatic uninstall may not have completed successfully. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
+                        'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
+            if V = IDNO then
+              Result := False;
+          end;
+        end
+        else
+        begin
+          V := MsgBox('Failed to automatically uninstall the existing version. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
                       'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
           if V = IDNO then
             Result := False;
         end;
       end
       else
-      begin
-        V := MsgBox('Failed to automatically uninstall the existing version. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
-                    'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
-        if V = IDNO then
-          Result := False;
-      end;
-    end
-    else
-      Result := False; //when older version present and user chose not to uninstall
+        Result := False; //when older version present and user chose not to uninstall
+    end;
   end;
 end;
 

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -227,33 +227,57 @@ begin
   
   if IsGeoDaInstalled then
   begin
-    V := MsgBox('An existing version of GeoDa was detected. Would you like to automatically uninstall it before installing the new version?' + #13#10 + #13#10 + 
-                'Click Yes to automatically uninstall the existing version.' + #13#10 +
-                'Click No to cancel the installation.', mbInformation, MB_YESNO);
-    if V = IDYES then
+    // Check if installer is running in silent mode
+    if WizardSilent() then
     begin
+      // In silent mode, automatically uninstall existing version
       UninstallAttempted := True;
       if UninstallExistingGeoDa() then
       begin
         // Check if uninstall was successful
         if IsGeoDaInstalled then
         begin
-          V := MsgBox('The automatic uninstall may not have completed successfully. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
+          // In silent mode, continue anyway to avoid blocking
+          Log('Warning: Automatic uninstall may not have completed successfully, but continuing with installation in silent mode.');
+        end;
+      end
+      else
+      begin
+        // In silent mode, continue anyway to avoid blocking
+        Log('Warning: Failed to automatically uninstall existing version, but continuing with installation in silent mode.');
+      end;
+    end
+    else
+    begin
+      // Interactive mode - show message box
+      V := MsgBox('An existing version of GeoDa was detected. Would you like to automatically uninstall it before installing the new version?' + #13#10 + #13#10 + 
+                  'Click Yes to automatically uninstall the existing version.' + #13#10 +
+                  'Click No to cancel the installation.', mbInformation, MB_YESNO);
+      if V = IDYES then
+      begin
+        UninstallAttempted := True;
+        if UninstallExistingGeoDa() then
+        begin
+          // Check if uninstall was successful
+          if IsGeoDaInstalled then
+          begin
+            V := MsgBox('The automatic uninstall may not have completed successfully. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
+                        'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
+            if V = IDNO then
+              Result := False;
+          end;
+        end
+        else
+        begin
+          V := MsgBox('Failed to automatically uninstall the existing version. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
                       'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
           if V = IDNO then
             Result := False;
         end;
       end
       else
-      begin
-        V := MsgBox('Failed to automatically uninstall the existing version. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
-                    'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
-        if V = IDNO then
-          Result := False;
-      end;
-    end
-    else
-      Result := False; //when older version present and user chose not to uninstall
+        Result := False; //when older version present and user chose not to uninstall
+    end;
   end;
 end;
 

--- a/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa-win7+.iss
@@ -176,21 +176,71 @@ begin
             RegValueExists(HKEY_CURRENT_USER,'Software\Microsoft\Windows\CurrentVersion\Uninstall\GeoDa_is2', 'UninstallString');
 end;
 
+function GetUninstallParameters: string;
+var
+  UninstallParams: string;
+  i: Integer;
+  HasSilentMode: Boolean;
+  HasSuppressMsgBox: Boolean;
+begin
+  UninstallParams := '';
+  HasSilentMode := False;
+  HasSuppressMsgBox := False;
+  
+  // Check all parameters for silent mode and suppress message box flags
+  for i := 1 to ParamCount do
+  begin
+    if ParamStr(i) = '/VERYSILENT' then
+    begin
+      UninstallParams := '/VERYSILENT';
+      HasSilentMode := True;
+    end
+    else if ParamStr(i) = '/SILENT' then
+    begin
+      if not HasSilentMode then
+      begin
+        UninstallParams := '/SILENT';
+        HasSilentMode := True;
+      end;
+    end
+    else if ParamStr(i) = '/SUPPRESSMSGBOXES' then
+    begin
+      HasSuppressMsgBox := True;
+    end;
+  end;
+  
+  // If no silent mode was found, default to /SILENT for interactive mode
+  if not HasSilentMode then
+  begin
+    UninstallParams := '/SILENT';
+  end;
+  
+  // Add /SUPPRESSMSGBOXES if it was found
+  if HasSuppressMsgBox then
+  begin
+    UninstallParams := UninstallParams + ' /SUPPRESSMSGBOXES';
+  end;
+  
+  Result := UninstallParams;
+end;
+
 function UninstallExistingGeoDa: Boolean;
 var
   iResultCode: Integer;
   sUnInstallString: string;
   UninstallSuccess: Boolean;
+  UninstallParams: string;
 begin
   Result := True;
   UninstallSuccess := False;
+  UninstallParams := GetUninstallParameters();
   
   // Try first uninstall string
   sUnInstallString := GetUninstallString();
   if sUnInstallString <> '' then
   begin
     sUnInstallString := RemoveQuotes(sUnInstallString);
-    if Exec(ExpandConstant(sUnInstallString), '/SILENT', '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
+    if Exec(ExpandConstant(sUnInstallString), UninstallParams, '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
     begin
       UninstallSuccess := True;
     end;
@@ -203,7 +253,7 @@ begin
     if sUnInstallString <> '' then
     begin
       sUnInstallString := RemoveQuotes(sUnInstallString);
-      if Exec(ExpandConstant(sUnInstallString), '/SILENT', '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
+      if Exec(ExpandConstant(sUnInstallString), UninstallParams, '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
       begin
         UninstallSuccess := True;
       end;

--- a/BuildTools/windows/installer/64bit/GeoDa.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa.iss
@@ -174,21 +174,71 @@ begin
             RegValueExists(HKEY_CURRENT_USER,'Software\Microsoft\Windows\CurrentVersion\Uninstall\GeoDa_is2', 'UninstallString');
 end;
 
+function GetUninstallParameters: string;
+var
+  UninstallParams: string;
+  i: Integer;
+  HasSilentMode: Boolean;
+  HasSuppressMsgBox: Boolean;
+begin
+  UninstallParams := '';
+  HasSilentMode := False;
+  HasSuppressMsgBox := False;
+  
+  // Check all parameters for silent mode and suppress message box flags
+  for i := 1 to ParamCount do
+  begin
+    if ParamStr(i) = '/VERYSILENT' then
+    begin
+      UninstallParams := '/VERYSILENT';
+      HasSilentMode := True;
+    end
+    else if ParamStr(i) = '/SILENT' then
+    begin
+      if not HasSilentMode then
+      begin
+        UninstallParams := '/SILENT';
+        HasSilentMode := True;
+      end;
+    end
+    else if ParamStr(i) = '/SUPPRESSMSGBOXES' then
+    begin
+      HasSuppressMsgBox := True;
+    end;
+  end;
+  
+  // If no silent mode was found, default to /SILENT for interactive mode
+  if not HasSilentMode then
+  begin
+    UninstallParams := '/SILENT';
+  end;
+  
+  // Add /SUPPRESSMSGBOXES if it was found
+  if HasSuppressMsgBox then
+  begin
+    UninstallParams := UninstallParams + ' /SUPPRESSMSGBOXES';
+  end;
+  
+  Result := UninstallParams;
+end;
+
 function UninstallExistingGeoDa: Boolean;
 var
   iResultCode: Integer;
   sUnInstallString: string;
   UninstallSuccess: Boolean;
+  UninstallParams: string;
 begin
   Result := True;
   UninstallSuccess := False;
+  UninstallParams := GetUninstallParameters();
   
   // Try first uninstall string
   sUnInstallString := GetUninstallString();
   if sUnInstallString <> '' then
   begin
     sUnInstallString := RemoveQuotes(sUnInstallString);
-    if Exec(ExpandConstant(sUnInstallString), '/SILENT', '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
+    if Exec(ExpandConstant(sUnInstallString), UninstallParams, '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
     begin
       UninstallSuccess := True;
     end;
@@ -201,7 +251,7 @@ begin
     if sUnInstallString <> '' then
     begin
       sUnInstallString := RemoveQuotes(sUnInstallString);
-      if Exec(ExpandConstant(sUnInstallString), '/SILENT', '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
+      if Exec(ExpandConstant(sUnInstallString), UninstallParams, '', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
       begin
         UninstallSuccess := True;
       end;

--- a/BuildTools/windows/installer/64bit/GeoDa.iss
+++ b/BuildTools/windows/installer/64bit/GeoDa.iss
@@ -225,33 +225,57 @@ begin
   
   if IsGeoDaInstalled then
   begin
-    V := MsgBox('An existing version of GeoDa was detected. Would you like to automatically uninstall it before installing the new version?' + #13#10 + #13#10 + 
-                'Click Yes to automatically uninstall the existing version.' + #13#10 +
-                'Click No to cancel the installation.', mbInformation, MB_YESNO);
-    if V = IDYES then
+    // Check if installer is running in silent mode
+    if WizardSilent() then
     begin
+      // In silent mode, automatically uninstall existing version
       UninstallAttempted := True;
       if UninstallExistingGeoDa() then
       begin
         // Check if uninstall was successful
         if IsGeoDaInstalled then
         begin
-          V := MsgBox('The automatic uninstall may not have completed successfully. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
+          // In silent mode, continue anyway to avoid blocking
+          Log('Warning: Automatic uninstall may not have completed successfully, but continuing with installation in silent mode.');
+        end;
+      end
+      else
+      begin
+        // In silent mode, continue anyway to avoid blocking
+        Log('Warning: Failed to automatically uninstall existing version, but continuing with installation in silent mode.');
+      end;
+    end
+    else
+    begin
+      // Interactive mode - show message box
+      V := MsgBox('An existing version of GeoDa was detected. Would you like to automatically uninstall it before installing the new version?' + #13#10 + #13#10 + 
+                  'Click Yes to automatically uninstall the existing version.' + #13#10 +
+                  'Click No to cancel the installation.', mbInformation, MB_YESNO);
+      if V = IDYES then
+      begin
+        UninstallAttempted := True;
+        if UninstallExistingGeoDa() then
+        begin
+          // Check if uninstall was successful
+          if IsGeoDaInstalled then
+          begin
+            V := MsgBox('The automatic uninstall may not have completed successfully. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
+                        'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
+            if V = IDNO then
+              Result := False;
+          end;
+        end
+        else
+        begin
+          V := MsgBox('Failed to automatically uninstall the existing version. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
                       'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
           if V = IDNO then
             Result := False;
         end;
       end
       else
-      begin
-        V := MsgBox('Failed to automatically uninstall the existing version. Would you like to continue with the installation anyway?' + #13#10 + #13#10 +
-                    'Note: This may cause conflicts with the existing installation.', mbConfirmation, MB_YESNO);
-        if V = IDNO then
-          Result := False;
-      end;
-    end
-    else
-      Result := False; //when older version present and user chose not to uninstall
+        Result := False; //when older version present and user chose not to uninstall
+    end;
   end;
 end;
 

--- a/version.h
+++ b/version.h
@@ -24,7 +24,7 @@ namespace Gda {
 const int version_major = 1;
 const int version_minor = 22;
 const int version_build = 0;
-const int version_subbuild = 19;
+const int version_subbuild = 20;
 const int version_year = 2025;
 const int version_month = 7;
 const int version_day = 25;

--- a/version.h
+++ b/version.h
@@ -24,7 +24,7 @@ namespace Gda {
 const int version_major = 1;
 const int version_minor = 22;
 const int version_build = 0;
-const int version_subbuild = 18;
+const int version_subbuild = 19;
 const int version_year = 2025;
 const int version_month = 7;
 const int version_day = 25;

--- a/version.h
+++ b/version.h
@@ -27,7 +27,7 @@ const int version_build = 0;
 const int version_subbuild = 20;
 const int version_year = 2025;
 const int version_month = 7;
-const int version_day = 25;
+const int version_day = 31;
 const int version_night = 0;
 const int version_type = 2;  // 0: alpha, 1: beta, 2: release
 }  // namespace Gda


### PR DESCRIPTION
This pull request introduces enhancements to the GeoDa installer scripts to improve the handling of existing installations, particularly in silent mode, and updates the version number. The most significant changes include adding logic for silent mode uninstallation and incrementing the version subbuild.

### Enhancements to installer behavior:

* Added logic to all installer scripts (`GeoDa-win7+.iss` and `GeoDa.iss` for both 32-bit and 64-bit versions) to handle existing installations in silent mode. If the installer is running in silent mode, it will attempt to uninstall the existing version automatically. If the uninstallation fails, the installation will proceed with warnings logged to avoid blocking. In interactive mode, the existing behavior of prompting the user remains unchanged. [[1]](diffhunk://#diff-48065651d2ee17b88efee7702b0c514b2c529ea7a6d2516a16ee395d2146e435R211-R233) [[2]](diffhunk://#diff-48065651d2ee17b88efee7702b0c514b2c529ea7a6d2516a16ee395d2146e435R263) [[3]](diffhunk://#diff-aa730bd9cd241d338c1a2c7ee283e7bacedd2c5c5307237fdbaddbe01ec4d1afR210-R232) [[4]](diffhunk://#diff-aa730bd9cd241d338c1a2c7ee283e7bacedd2c5c5307237fdbaddbe01ec4d1afR262) [[5]](diffhunk://#diff-cbabf452ba891cfb927a897bc95cd0091be8b4ee21af9e6d204b457634a0bde2R230-R252) [[6]](diffhunk://#diff-cbabf452ba891cfb927a897bc95cd0091be8b4ee21af9e6d204b457634a0bde2R282) [[7]](diffhunk://#diff-7fc496427f6ddc996b6d6a7e16aab967a365f3f76e8cb1d5dac0f5347021cf52R228-R250) [[8]](diffhunk://#diff-7fc496427f6ddc996b6d6a7e16aab967a365f3f76e8cb1d5dac0f5347021cf52R280)

### Version update:

* Incremented the `version_subbuild` from 18 to 19 in `version.h` to reflect the new changes.