### PR TITLE
Fix null pointer dereference in FramesManager::notifyObservers

### DIFF
--- a/FramesManager.cpp
+++ b/FramesManager.cpp
@@ -70,7 +70,9 @@ void FramesManager::notifyObservers()
 {
 	for (std::list<FramesManagerObserver*>::iterator it=observers.begin();
 		 it != observers.end(); ++it) {
-		(*it)->update(this);
+		if (*it != nullptr) {
+			(*it)->update(this);
+		}
 	}
 }
 


### PR DESCRIPTION
## Bug Description

The `notifyObservers()` method in `FramesManager.cpp` iterates through the observers list and calls `update()` on each observer without checking if the pointer is null. If a null pointer is added to the observers list (which could happen through `registerObserver`), this will cause a crash when `update()` is called on a null pointer.

## Fix

Added a null check before dereferencing the iterator and calling `update()`:

```cpp
if (*it != nullptr) {
    (*it)->update(this);
}
```

## Testing

This fix prevents crashes when null pointers are present in the observers list. The null check ensures that only valid observer pointers have their `update()` method called.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.