### PR TITLE
ci: fix create_release.yml to download artifacts from build runs

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -46,44 +46,59 @@ jobs:
 
       - name: Wait for builds to complete
         run: |
-          echo "Waiting for build workflows to complete..."
+          # Wait until every build workflow (Windows, macOS, Ubuntu, AppImage)
+          # triggered by this tag push has finished, so their artifacts exist
+          # before we download them. Polls the runs API every 30s.
+          COMMIT_SHA=$(git rev-parse HEAD)
+          echo "Waiting for build workflows on ${COMMIT_SHA}..."
+          for attempt in $(seq 1 180); do
+            RUNS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${COMMIT_SHA}" \
+              --jq '[.workflow_runs[] | select(.name != "Create Release")]')
+            TOTAL=$(echo "$RUNS" | jq 'length')
+            if [ "$TOTAL" -eq 0 ]; then
+              echo "  no build runs found yet (attempt $attempt/180); waiting 30s..."
+              sleep 30
+              continue
+            fi
+            DONE=$(echo "$RUNS" | jq '[.[] | select(.status == "completed")] | length')
+            FAILED=$(echo "$RUNS" | jq '[.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")] | length')
+            echo "  completed $DONE/$TOTAL, failed $FAILED (attempt $attempt/180)"
+            if [ "$DONE" -eq "$TOTAL" ]; then
+              if [ "$FAILED" -gt 0 ]; then
+                echo "::warning::One or more build workflows failed; proceeding with available artifacts"
+              fi
+              break
+            fi
+            sleep 30
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          # Function to check if all required workflows are complete
-          check_workflows() {
-            local max_attempts=120  # 2 hours maximum (120 * 60 seconds)
-            local attempt=1
-            
-            while [ $attempt -le $max_attempts ]; do
-              echo "Checking build status (attempt $attempt/$max_attempts)..."
-              
-              # Get the current commit SHA
-              COMMIT_SHA=$(git rev-parse HEAD)
-              
-              # Check if all three build workflows have completed successfully
-              # We'll use a simple approach: wait and then proceed
-              # The download-artifact action will handle missing artifacts gracefully
-              
-              echo "Waiting 60 seconds before next check..."
-              sleep 60
-              attempt=$((attempt + 1))
-            done
-            
-            echo "Maximum wait time reached. Proceeding with available artifacts..."
-          }
-
-          # Start the check process
-          check_workflows
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          pattern: 'GeoDa-*'
+      - name: Download all build artifacts
+        # download-artifact@v4 without run-id only looks in the CURRENT run
+        # (the Create Release run), which has no artifacts. Pull from every
+        # build workflow run at this commit instead.
+        run: |
+          mkdir -p artifacts
+          COMMIT_SHA=$(git rev-parse HEAD)
+          RUN_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${COMMIT_SHA}" \
+            --jq '.workflow_runs[] | select(.name != "Create Release") | .id')
+          if [ -z "$RUN_IDS" ]; then
+            echo "::error::No build workflow runs found for ${COMMIT_SHA}"
+            exit 1
+          fi
+          for RUN_ID in $RUN_IDS; do
+            echo "Downloading artifacts from run ${RUN_ID}"
+            gh run download "${RUN_ID}" --repo "${GITHUB_REPOSITORY}" \
+              --dir artifacts --pattern 'GeoDa-*'
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: List downloaded artifacts
         run: |
           echo "Downloaded artifacts:"
-          find artifacts -type f -name "*.dmg" -o -name "*.exe" -o -name "*.deb" | sort
+          find artifacts -type f -print | sort
 
       - name: Create Release
         id: create_release
@@ -183,17 +198,6 @@ jobs:
           asset_content_type: application/octet-stream
         continue-on-error: true
 
-      - name: Upload Ubuntu 20.04 Package
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifacts/GeoDa-${{ steps.get_version.outputs.version }}-focal/geoda_${{ steps.get_version.outputs.version }}-1focal1_amd64.deb
-          asset_name: geoda_${{ steps.get_version.outputs.version }}-1focal1_amd64.deb
-          asset_content_type: application/vnd.debian.binary-package
-        continue-on-error: true
-
       - name: Upload Ubuntu 22.04 Package
         uses: actions/upload-release-asset@v1
         env:
@@ -214,6 +218,17 @@ jobs:
           asset_path: ./artifacts/GeoDa-${{ steps.get_version.outputs.version }}-noble/geoda_${{ steps.get_version.outputs.version }}-1noble1_amd64.deb
           asset_name: geoda_${{ steps.get_version.outputs.version }}-1noble1_amd64.deb
           asset_content_type: application/vnd.debian.binary-package
+        continue-on-error: true
+
+      - name: Upload AppImage
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./artifacts/GeoDa-${{ steps.get_version.outputs.version }}-AppImage/GeoDa-${{ steps.get_version.outputs.version }}-x86_64.AppImage
+          asset_name: GeoDa-${{ steps.get_version.outputs.version }}-x86_64.AppImage
+          asset_content_type: application/octet-stream
         continue-on-error: true
 
       - name: Verify Release Assets


### PR DESCRIPTION
## Problem

The `Create Release` workflow (triggered on `v*` tag pushes) shipped release **v1.22.1 with zero assets**. Root cause: the `actions/download-artifact@v4` step had no `run-id` or `github-token`, so it only searched the Create Release run itself — which has no artifacts — found 0, and every `upload-release-asset` step failed with `ENOENT`.

## Fix

- **Download step**: replaced `download-artifact@v4` with `gh run download` over every build workflow run (Windows, macOS, Ubuntu, AppImage) at the tag commit, extracting into `artifacts/<artifact-name>/` — the exact layout the upload steps expect.
- **Wait step**: now polls the runs API every 30s until all build workflows complete (or 90 min cap), instead of sleeping a fixed 2 hours regardless of build status.
- **Ubuntu focal upload**: removed — focal is no longer in the Ubuntu build matrix (only noble + jammy), so that step could never succeed.
- **AppImage upload**: added — the appimage build produces `GeoDa-<ver>-x86_64.AppImage` but it was never attached to releases.

## Validation

The v1.22.1 release was manually completed with all 10 installers (2 DMGs, 5 Windows exes, 2 debs, 1 AppImage) by downloading the build-run artifacts and uploading them directly — confirming the artifact names/layout match the upload paths in this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)